### PR TITLE
Error Boundary Header Ticket PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-error-boundary": "^6.0.0",
     "react-phone-number-input": "^3.4.13",
     "shiki": "^3.14.0",
     "sonner": "^2.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      react-error-boundary:
+        specifier: ^6.0.0
+        version: 6.0.0(react@19.2.0)
       react-phone-number-input:
         specifier: ^3.4.13
         version: 3.4.13(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -248,6 +251,10 @@ packages:
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -4291,6 +4298,11 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-error-boundary@6.0.0:
+    resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
+    peerDependencies:
+      react: '>=16.13.1'
+
   react-hook-form@7.66.0:
     resolution: {integrity: sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==}
     engines: {node: '>=18.0.0'}
@@ -5004,6 +5016,8 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/runtime@7.28.4': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -9426,6 +9440,11 @@ snapshots:
     dependencies:
       react: 19.2.0
       scheduler: 0.27.0
+
+  react-error-boundary@6.0.0(react@19.2.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      react: 19.2.0
 
   react-hook-form@7.66.0(react@19.2.0):
     dependencies:

--- a/src/app/(app)/error.tsx
+++ b/src/app/(app)/error.tsx
@@ -1,5 +1,15 @@
 "use client";
 
-export default function Error() {
-  return <p>Ooops...</p>;
+import {useEffect} from "react"
+import {logger} from "@/lib/logger"
+
+export default function Error({
+  error,
+} : {error: Error & {digest?: string}
+}) {
+  useEffect(() => {
+    logger.error(error)
+  }, [error])
+
+  return <p>Something broke DDD:</p>;
 }

--- a/src/components/navigation/NavBar.tsx
+++ b/src/components/navigation/NavBar.tsx
@@ -4,6 +4,8 @@ import { use } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { FlagValues } from "flags/react";
+import { ErrorBoundary } from "react-error-boundary";
+import { NavErrorFallback } from "../navigation/NavError"
 
 export function NavBar({
   flags,
@@ -25,42 +27,48 @@ export function NavBar({
           scheduler: schedulerFlag,
         }}
       />
-      {roomsFlag && (
+      <ErrorBoundary FallbackComponent = {NavErrorFallback}>
+        {roomsFlag && (
+          <Link
+            href="/rooms"
+            data-active={pathname === "/rooms"}
+            className="bg-neu1 flex items-center gap-2 rounded-full border-1 px-4 py-2 text-sm"
+          >
+            <DoorOpen className="size-4" />
+            <span>Rooms</span>
+          </Link>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary FallbackComponent = {NavErrorFallback}>
         <Link
-          href="/rooms"
-          data-active={pathname === "/rooms"}
-          className="bg-neu1 flex items-center gap-2 rounded-full border-1 px-4 py-2 text-sm"
+          href="/catalog"
+          data-active={pathname.startsWith("/catalog")}
+          className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center gap-2 rounded-full border-1 px-4 py-2 text-sm"
         >
-          <DoorOpen className="size-4" />
-          <span>Rooms</span>
+            <Bookmark className="size-4" />
+            <span>Catalog</span>
         </Link>
-      )}
-      <Link
-        href="/catalog"
-        data-active={pathname.startsWith("/catalog")}
-        className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center gap-2 rounded-full border-1 px-4 py-2 text-sm"
-      >
-        <Bookmark className="size-4" />
-        <span>Catalog</span>
-      </Link>
-      {schedulerFlag && (
-        <Link
-          href="/scheduler"
-          data-active={pathname === "/scheduler"}
-          className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center rounded-full border-1 p-2 text-sm"
-        >
-          Scheduler
-        </Link>
-      )}
-      {faqFlag && (
-        <Link
-          href="/faq"
-          data-active={pathname === "/faq"}
-          className="bg-neu1 data-[active=true]:border-neu3 flex items-center rounded-full border-1 p-2 text-sm"
-        >
-          <CircleQuestionMark className="text-red size-5" />
-        </Link>
-      )}
+        {schedulerFlag && (
+          <Link
+            href="/scheduler"
+            data-active={pathname === "/scheduler"}
+            className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center rounded-full border-1 p-2 text-sm"
+          >
+            Scheduler
+          </Link>
+        )}
+      </ErrorBoundary>
+      <ErrorBoundary FallbackComponent={NavErrorFallback}>
+        {faqFlag && (
+          <Link
+            href="/faq"
+            data-active={pathname === "/faq"}
+            className="bg-neu1 data-[active=true]:border-neu3 flex items-center rounded-full border-1 p-2 text-sm"
+          >
+            <CircleQuestionMark className="text-red size-5" />
+          </Link>
+        )}
+      </ErrorBoundary>
     </nav>
   );
 }

--- a/src/components/navigation/NavError.tsx
+++ b/src/components/navigation/NavError.tsx
@@ -1,0 +1,7 @@
+export function NavErrorFallback({ error }: {error: Error}) {
+    return (
+      <div className="text-red-600">
+        <h2>????</h2>
+      </div>
+    );
+  }

--- a/src/components/navigation/UserMenu.tsx
+++ b/src/components/navigation/UserMenu.tsx
@@ -12,17 +12,20 @@ import {
 import { Avatar, AvatarFallback } from "../ui/avatar";
 import { Iconskie } from "../icons/Iconskie";
 import { useAuth, signOut } from "@/lib/auth/client";
+import { ErrorBoundary } from "react-error-boundary";
+import { NavErrorFallback } from "../navigation/NavError"
 
 export function UserIcon() {
   const [showSI, setShowSI] = useState(false);
   const { user, isPending } = useAuth();
 
   if (!isPending && user.guid) {
-    return <UserMenu />;
+    return <ErrorBoundary FallbackComponent={NavErrorFallback}><UserMenu /></ErrorBoundary>;
   }
 
   return (
     <>
+    <ErrorBoundary FallbackComponent={NavErrorFallback}>
       <Button
         className="bg-accent hover:bg-accent/80 h-9 rounded-full font-bold"
         onClick={() => setShowSI(!showSI)}
@@ -30,6 +33,7 @@ export function UserIcon() {
         Sign In
       </Button>
       {showSI && <SignIn closeFn={() => setShowSI(false)} />}
+    </ErrorBoundary>
     </>
   );
 }


### PR DESCRIPTION
Added error boundary from react to pnpm dependencies; 
Wrote navbar error fallback draft component; still need designs for these, if any
Did NOT encompass the specific google auth/sms verification components yet; my reasoning is that if any of these components somehow fail on the serve-side, then it's best to not let the user  have the ability to attempt sign in/up.

-> I'm unsure if their is anything on the client-rendering I need to handle with error boundaries;