### PR TITLE
Filter Bar and Online Filter

### DIFF
--- a/src/components/feedback/FeedbackModal.tsx
+++ b/src/components/feedback/FeedbackModal.tsx
@@ -6,15 +6,13 @@ import {
   DialogTrigger,
 } from "../ui/dialog";
 
-export default function FeedbackModal({children}: {children?: React.ReactNode}) {
+export default function FeedbackModal() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        {children || (
         <button className="bg-r4 fixed right-0 bottom-56 z-10 flex origin-bottom-right rotate-[-90deg] flex-col rounded-t-sm px-4 py-1 text-xs text-white uppercase">
           Feedback
         </button>
-      )}
       </DialogTrigger>
       <DialogContent className="lg:slide-in-from-right lg:slide-out-to-right lg:data-[state=closed]:zoom-out-100 lg:data-[state=open]:zoom-in-100 fixed lg:top-auto lg:right-2 lg:bottom-2 lg:left-auto lg:max-w-[320px] lg:translate-x-[0] lg:translate-y-[0]">
         <DialogTitle className="hidden">Feedback</DialogTitle>

--- a/src/components/feedback/FeedbackModal.tsx
+++ b/src/components/feedback/FeedbackModal.tsx
@@ -6,13 +6,15 @@ import {
   DialogTrigger,
 } from "../ui/dialog";
 
-export default function FeedbackModal() {
+export default function FeedbackModal({children}: {children?: React.ReactNode}) {
   return (
     <Dialog>
       <DialogTrigger asChild>
+        {children || (
         <button className="bg-r4 fixed right-0 bottom-56 z-10 flex origin-bottom-right rotate-[-90deg] flex-col rounded-t-sm px-4 py-1 text-xs text-white uppercase">
           Feedback
         </button>
+      )}
       </DialogTrigger>
       <DialogContent className="lg:slide-in-from-right lg:slide-out-to-right lg:data-[state=closed]:zoom-out-100 lg:data-[state=open]:zoom-in-100 fixed lg:top-auto lg:right-2 lg:bottom-2 lg:left-auto lg:max-w-[320px] lg:translate-x-[0] lg:translate-y-[0]">
         <DialogTitle className="hidden">Feedback</DialogTitle>

--- a/src/components/scheduler/FilterMultiSelect.tsx
+++ b/src/components/scheduler/FilterMultiSelect.tsx
@@ -36,7 +36,6 @@ export function FilterMultiSelect({
   options,
   selected,
   onSelectedChange,
-  placeholder = "Select options",
 }: FilterMultiSelectProps) {
   const [open, setOpen] = useState(false);
 
@@ -110,7 +109,7 @@ export function FilterMultiSelect({
               >
                 <CommandInput
                   placeholder={`Search ${label.toLowerCase()}...`}
-                  className="text-sm"
+                  className="text-xs"
                 />
                 <CommandList className="max-h-[300px]">
                   <CommandEmpty>No results found</CommandEmpty>
@@ -158,7 +157,7 @@ export function FilterMultiSelect({
           {selectedOptions.slice(0, 3).map((opt) => (
             <span
               key={opt.value}
-              className="inline-flex w-fit items-center rounded-full border bg-secondary px-3 py-1 text-sm"
+              className="inline-flex w-fit items-center rounded-full border bg-secondary px-3 py-1 text-xs"
             >
               <span className="flex items-center gap-2">
                 {opt.value !== opt.label && (
@@ -184,7 +183,7 @@ export function FilterMultiSelect({
             </span>
           ))}
           {selectedOptions.length > 3 && (
-            <span className="rounded-full border px-3 py-1 text-sm">
+            <span className="rounded-full border px-3 py-1 text-xs">
               +{selectedOptions.length - 3}
             </span>
           )}

--- a/src/components/scheduler/FilterMultiSelect.tsx
+++ b/src/components/scheduler/FilterMultiSelect.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Command,
+  CommandInput,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandEmpty,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { PlusIcon } from 'lucide-react';
+import { cn } from "@/lib/cn";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface FilterMultiSelectProps {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onSelectedChange: (values: string[]) => void;
+  placeholder?: string;
+}
+
+export function FilterMultiSelect({
+  label,
+  options,
+  selected,
+  onSelectedChange,
+  placeholder = "Select options",
+}: FilterMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const selectedOptions = options.filter((opt) =>
+    selected.includes(opt.value)
+  );
+
+  const clearAll = () => {
+    onSelectedChange([]);
+  };
+
+  const toggleOption = (optionValue: string) => {
+    const option = options.find((opt) => opt.value === optionValue);
+    if (!option) return;
+
+    if (selected.includes(optionValue)) {
+      onSelectedChange(selected.filter((v) => v !== optionValue));
+    } else {
+      onSelectedChange([...selected, optionValue]);
+    }
+  };
+
+  const removeOption = (optionValue: string) => {
+    onSelectedChange(selected.filter((v) => v !== optionValue));
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <Label className="text-muted-foreground text-xs font-bold">
+          {label}
+        </Label>
+        <div className="flex items-center gap-2">
+          {selected.length > 0 && (
+            <button
+              onClick={clearAll}
+              className="text-blue-600 hover:text-blue-600/80 text-xs"
+            >
+              Clear all
+            </button>
+          )}
+
+          <Popover open={open} onOpenChange={setOpen} modal={true}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <PlusIcon
+                  className={cn(
+                    "size-5 transition-transform",
+                    open && "rotate-45"
+                  )}
+                />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-[280px] p-0"
+              align="end"
+            >
+              <Command
+                filter={(value, search, keywords) => {
+                  const v = value.toLowerCase();
+                  const s = search.toLowerCase();
+                  const label = keywords?.join(" ").toLowerCase();
+                  if (v === s) return 1;
+                  if (v.includes(s)) return 0.8;
+                  if (label?.includes(s)) return 0.7;
+                  return 0;
+                }}
+              >
+                <CommandInput
+                  placeholder={`Search ${label.toLowerCase()}...`}
+                  className="text-sm"
+                />
+                <CommandList className="max-h-[300px]">
+                  <CommandEmpty>No results found</CommandEmpty>
+                  <CommandGroup>
+                    {options.map((opt) => (
+                      <CommandItem
+                        key={opt.value}
+                        value={opt.value}
+                        keywords={[opt.label]}
+                        onSelect={toggleOption}
+                        className={cn(
+                          "flex items-center gap-2 py-3 px-4 cursor-pointer",
+                          selected.includes(opt.value) && "font-semibold"
+                        )}
+                      >
+                        {opt.value !== opt.label && (
+                          <div
+                            className={cn("font-bold text-muted-foreground", {
+                              "text-foreground": selected.includes(opt.value),
+                            })}
+                          >
+                            {opt.value}
+                          </div>
+                        )}
+                        <div
+                          className={cn("text-muted-foreground", {
+                            "text-foreground font-semibold": selected.includes(
+                              opt.value
+                            ),
+                          })}
+                        >
+                          {opt.label}
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+      {selectedOptions.length > 0 && (
+        <div className="flex flex-wrap gap-2 pt-3">
+          {selectedOptions.slice(0, 3).map((opt) => (
+            <span
+              key={opt.value}
+              className="inline-flex w-fit items-center rounded-full border bg-secondary px-3 py-1 text-sm"
+            >
+              <span className="flex items-center gap-2">
+                {opt.value !== opt.label && (
+                  <span className="font-bold text-foreground">{opt.value}</span>
+                )}
+                <span
+                  className={cn(
+                    opt.value === opt.label
+                      ? "text-foreground"
+                      : "text-muted-foreground"
+                  )}
+                >
+                  {opt.label}
+                </span>
+              </span>
+              <button
+                onClick={() => removeOption(opt.value)}
+                aria-label={`Remove ${opt.label}`}
+                className="ml-2 rounded-full py-0.5 text-lg leading-none text-muted-foreground hover:text-foreground"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {selectedOptions.length > 3 && (
+            <span className="rounded-full border px-3 py-1 text-sm">
+              +{selectedOptions.length - 3}
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -55,7 +55,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
     }
   };
 
-  const clearFilters = () => onFiltersChange({ isOnline: true });
+  const clearFilters = () => onFiltersChange({ includesOnline: true });
 
   const handleGenerate = () => {
     // Parse locked course IDs from input
@@ -228,14 +228,14 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         </span>
         <button
           type="button"
-          onClick={() => updateFilter("isOnline", !filters.isOnline)}
+          onClick={() => updateFilter("includesOnline", !filters.includesOnline)}
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ${
-            filters.isOnline ? "bg-red-500" : "bg-gray-300"
+            filters.includesOnline ? "bg-red-500" : "bg-gray-300"
           }`}
         >
           <span
             className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${
-              filters.isOnline ? "translate-x-6" : "translate-x-1"
+              filters.includesOnline ? "translate-x-6" : "translate-x-1"
             }`}
           />
         </button>
@@ -380,7 +380,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
       <Separator />
 
       {/* Include Honors Toggle */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between pb-20">
         <Label className="text-muted-foreground text-xs font-bold">
           INCLUDE HONORS
         </Label>
@@ -391,16 +391,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
           }
           className="data-[state=checked]:bg-red-500"
         />
-      </div>
-
-      <Separator />
-
-      <div className="pb-20">
-        <FeedbackModal>
-          <div className="text-xs text-neu font-semibold cursor-pointer hover:underline">
-            Have an idea for a filter? Let us know <MoveRightIcon className="inline h-3 w-3"/>      
-          </div>
-        </FeedbackModal>
       </div>
       
     </div>

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -8,6 +8,9 @@ import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import { CourseBox } from "@/components/scheduler/CourseBox";
 import { getCourseColorMap, getCourseKey } from "@/lib/scheduler/courseColors";
+import { FilterMultiSelect } from "./FilterMultiSelect";
+import { Switch } from "../ui/switch";
+import { TimeInput } from "./TimeInput";
 
 // Convert time string (e.g., "09:00") to military format (e.g., 900)
 function timeStringToMilitary(timeStr: string): number {
@@ -38,7 +41,10 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
   // Memoize the color map so it's only computed when filteredSchedules changes
   const colorMap = useMemo(() => getCourseColorMap(filteredSchedules), [filteredSchedules]);
 
-  const updateFilter = <K extends keyof ScheduleFilters>(key: K, value: ScheduleFilters[K]) => {
+  const updateFilter = <K extends keyof ScheduleFilters>(
+    key: K,
+    value: ScheduleFilters[K],
+  ) => {
     if (value === undefined || (Array.isArray(value) && value.length === 0)) {
       const { [key]: _, ...rest } = filters;
       onFiltersChange(rest);
@@ -47,7 +53,12 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
     }
   };
 
-  const clearFilters = () => onFiltersChange({});
+  const clearFilters = () => onFiltersChange({ isOnline: true });
+
+  const clearNUPaths = () => {
+    const { nupaths, ...rest } = filters;
+    onFiltersChange(rest);
+  };
 
   const handleGenerate = () => {
     // Parse locked course IDs from input
@@ -105,11 +116,11 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       <Separator />
 
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         <h3 className="text-muted-foreground text-xs font-bold">FILTERS</h3>
         <button
           onClick={clearFilters}
-          className="px-3 py-1 text-xs bg-red-100 hover:bg-red-200 text-red-700 rounded"
+          className="rounded bg-red-100 px-3 py-1 text-xs text-red-700 hover:bg-red-200"
         >
           Clear All
         </button>
@@ -164,66 +175,161 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       <Separator />
 
-      {/* Start Time Filter */}
-      <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          EARLIEST START TIME
-        </Label>
-        <input
-          type="time"
-          value={filters.startTime ? militaryToTimeString(filters.startTime) : ""}
-          onChange={(e) => updateFilter("startTime", e.target.value ? timeStringToMilitary(e.target.value) : undefined)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
-        />
+      <Separator />
+
+      {/* Classes Filter*/}
+      <div className="flex justify-between items-center">
+        <h3 className="text-muted-foreground text-xs font-bold">CLASSES</h3>
+        <button
+          onClick={() => {}}
+          aria-label="Edit classes"
+          title="Edit classes"
+          className="p-1 border border-transparent text-gray-600 rounded"
+        >
+          <Pencil className="w-4 h-4" />
+        </button>
       </div>
 
-      {/* End Time Filter */}
       <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          LATEST END TIME
-        </Label>
-        <input
-          type="time"
-          value={filters.endTime ? militaryToTimeString(filters.endTime) : ""}
-          onChange={(e) => updateFilter("endTime", e.target.value ? timeStringToMilitary(e.target.value) : undefined)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
-        />
+        {filteredSchedules && filteredSchedules.length > 0 && (
+          (() => {
+            // Build a map of course -> sections
+            const courseMap = new Map<string, Map<string, SectionWithCourse>>();
+            for (const schedule of filteredSchedules) {
+              for (const section of schedule) {
+                const courseKey = getCourseKey(section);
+                if (!courseMap.has(courseKey)) courseMap.set(courseKey, new Map());
+                const inner = courseMap.get(courseKey)!;
+                if (!inner.has(section.crn)) inner.set(section.crn, section);
+              }
+            }
+
+            // Sort courses alphabetically
+            const courseEntries = Array.from(courseMap.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+
+            return (
+              <div className="mt-2">
+                {courseEntries.map(([courseKey, sectionsMap]) => (
+                  <CourseBox
+                    key={courseKey}
+                    sections={Array.from(sectionsMap.values())}
+                    color={colorMap.get(courseKey)}
+                  />
+                ))}
+              </div>
+            );
+          })()
+        )}
+      </div>
+
+      <Separator />
+      
+      {/* Online Classes */}
+      <div className="mt-2 flex items-center justify-between">
+        <span className="text-muted-foreground text-xs font-bold">
+          INCLUDE REMOTE SECTIONS
+        </span>
+        <button
+          type="button"
+          onClick={() => updateFilter("isOnline", !filters.isOnline)}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ${
+            filters.isOnline ? "bg-red-500" : "bg-gray-300"
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform duration-200 ${
+              filters.isOnline ? "translate-x-6" : "translate-x-1"
+            }`}
+          />
+        </button>
       </div>
 
       <Separator />
 
-      {/* Min Days Free */}
-      <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          MIN DAYS FREE
-        </Label>
-        <input
-          type="number"
-          min="0"
-          max="7"
-          value={filters.minDaysFree ?? ""}
-          onChange={(e) => updateFilter("minDaysFree", e.target.value ? parseInt(e.target.value) : undefined)}
-          placeholder="0-7"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
-        />
+      {/* Time Section */}
+      <div className="space-y-3">
+        <Label className="text-muted-foreground text-xs font-bold">TIME</Label>
+        
+        <div className="flex items-center justify-between text-sm pb-1.5">
+          <span className="text-muted-foreground whitespace-nowrap">Start time is after</span>
+          <TimeInput
+            value={
+              filters.startTime ? militaryToTimeString(filters.startTime) : ""
+            }
+            onChange={(value) =>
+              updateFilter(
+                "startTime",
+                value ? timeStringToMilitary(value) : undefined
+              )
+            }
+          />
+        </div>
+
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground whitespace-nowrap">End time is before</span>
+          <TimeInput
+            value={filters.endTime ? militaryToTimeString(filters.endTime) : ""}
+            onChange={(value) =>
+              updateFilter(
+                "endTime",
+                value ? timeStringToMilitary(value) : undefined
+              )
+            }
+          />
+        </div>        
       </div>
 
-      {/* Days Free Checkboxes */}
-      <div>
-        <Label className="text-muted-foreground text-xs font-bold block mb-2">
-          SPECIFIC DAYS FREE
-        </Label>
-        <div className="flex flex-wrap gap-2">
+      <Separator />
+
+      {/* Free Days Section */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs font-bold">
+            FREE DAYS
+          </Label>
+          {(filters.specificDaysFree?.length ?? 0) > 0 && (
+            <button
+              onClick={() => updateFilter("specificDaysFree", undefined)}
+              className="text-blue-600 hover:text-blue-600/80 text-xs"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+
+        {/* Day number buttons */}
+        <div className="flex gap-2">
+          {[1, 2, 3, 4, 5, 6].map((num) => (
+            <button
+              key={num}
+              onClick={() => updateFilter("minDaysFree", num)}
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors ${
+                filters.minDaysFree === num
+                  ? "bg-red-500 text-white"
+                  : "border border-input bg-background text-foreground hover:bg-muted"
+              }`}
+            >
+              {num}
+            </button>
+          ))}
+        </div>
+
+        {/* Day checkboxes */}
+        <div className="space-y-2">
           {[
-            { value: 0, label: "Sun" },
-            { value: 1, label: "Mon" },
-            { value: 2, label: "Tue" },
-            { value: 3, label: "Wed" },
-            { value: 4, label: "Thu" },
-            { value: 5, label: "Fri" },
-            { value: 6, label: "Sat" },
+            { value: 1, label: "Monday" },
+            { value: 2, label: "Tuesday" },
+            { value: 3, label: "Wednesday" },
+            { value: 4, label: "Thursday" },
+            { value: 5, label: "Friday" },
+            { value: 6, label: "Saturday" },
+            { value: 0, label: "Sunday" },
           ].map((day) => (
-            <label key={day.value} className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
+            <label
+              key={day.value}
+              className="flex cursor-pointer items-center justify-between py-1"
+            >
+              <span className="text-sm text-muted-foreground">{day.label}</span>
               <input
                 type="checkbox"
                 checked={filters.specificDaysFree?.includes(day.value) ?? false}
@@ -231,12 +337,14 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
                   const currentDays = filters.specificDaysFree || [];
                   const newDays = e.target.checked
                     ? [...currentDays, day.value]
-                    : currentDays.filter(d => d !== day.value);
-                  updateFilter("specificDaysFree", newDays.length > 0 ? newDays : undefined);
+                    : currentDays.filter((d) => d !== day.value);
+                  updateFilter(
+                    "specificDaysFree",
+                    newDays.length > 0 ? newDays : undefined
+                  );
                 }}
-                className="rounded"
+                className="h-4 w-4 rounded border-input accent-red-500"
               />
-              <span className="text-sm">{day.label}</span>
             </label>
           ))}
         </div>
@@ -244,33 +352,16 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       <Separator />
 
-      {/* Min Seats Left */}
-      <div>
+      {/* Hide Filled Sections Toggle */}
+      <div className="flex items-center justify-between">
         <Label className="text-muted-foreground text-xs font-bold">
-          MIN SEATS AVAILABLE
+          HIDE FILLED SECTIONS
         </Label>
-        <input
-          type="number"
-          min="0"
-          value={filters.minSeatsLeft ?? ""}
-          onChange={(e) => updateFilter("minSeatsLeft", e.target.value ? parseInt(e.target.value) : undefined)}
-          placeholder="Any"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
-        />
-      </div>
-
-      {/* Min Honors Courses */}
-      <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          MIN HONORS COURSES
-        </Label>
-        <input
-          type="number"
-          min="0"
-          value={filters.minHonorsCourses ?? ""}
-          onChange={(e) => updateFilter("minHonorsCourses", e.target.value ? parseInt(e.target.value) : undefined)}
-          placeholder="Any"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
+        <Switch
+          checked={(filters.minSeatsLeft ?? 0) > 0}
+          onCheckedChange={(checked) =>
+            updateFilter("minSeatsLeft", checked ? 1 : undefined)
+          }
         />
       </div>
 
@@ -278,31 +369,33 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       {/* NUPath Requirement */}
       <div>
-        <Label className="text-muted-foreground text-xs font-bold block mb-2">
-          NUPATH REQUIREMENTS
-        </Label>
-        <div className="flex flex-wrap gap-2">
-          {nupathOptions.map((nupath) => (
-            <label key={nupath.value} className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
-              <input
-                type="checkbox"
-                checked={filters.nupaths?.includes(nupath.value) ?? false}
-                onChange={(e) => {
-                  const currentNupaths = filters.nupaths || [];
-                  const newNupaths = e.target.checked
-                    ? [...currentNupaths, nupath.value]
-                    : currentNupaths.filter(n => n !== nupath.value);
-                  updateFilter("nupaths", newNupaths.length > 0 ? newNupaths: undefined);
-                }}
-                className="rounded"
-              />
-              <span className="text-sm">
-                {nupath.label}
-              </span>
-            </label>
-          ))}
-        </div>
+        <FilterMultiSelect
+          label="NUPATHS"
+          options={nupathOptions}
+          selected={filters.nupaths ?? []}
+          onSelectedChange={(values) =>
+            updateFilter("nupaths", values.length > 0 ? values : undefined)
+          }
+          placeholder="Select NUPaths"
+        />
       </div>
+
+      <Separator />
+
+      {/* Include Honors Toggle */}
+      <div className="flex items-center justify-between">
+        <Label className="text-muted-foreground text-xs font-bold">
+          INCLUDE HONORS
+        </Label>
+        <Switch
+          checked={(filters.minHonorsCourses ?? 0) > 0}
+          onCheckedChange={(checked) =>
+            updateFilter("minHonorsCourses", checked ? 1 : undefined)
+          }
+          className="data-[state=checked]:bg-red-500"
+        />
+      </div>
+
     </div>
   );
 }

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -11,6 +11,8 @@ import { getCourseColorMap, getCourseKey } from "@/lib/scheduler/courseColors";
 import { FilterMultiSelect } from "./FilterMultiSelect";
 import { Switch } from "../ui/switch";
 import { TimeInput } from "./TimeInput";
+import { MoveRightIcon } from "lucide-react";
+import FeedbackModal from "../feedback/FeedbackModal";
 
 // Convert time string (e.g., "09:00") to military format (e.g., 900)
 function timeStringToMilitary(timeStr: string): number {
@@ -55,11 +57,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
   const clearFilters = () => onFiltersChange({ isOnline: true });
 
-  const clearNUPaths = () => {
-    const { nupaths, ...rest } = filters;
-    onFiltersChange(rest);
-  };
-
   const handleGenerate = () => {
     // Parse locked course IDs from input
     const lockedCourseIds = lockedCourseIdsInput
@@ -79,7 +76,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
   };
 
   return (
-    <div className="bg-background h-[calc(100vh-72px)] w-full space-y-4 overflow-y-scroll px-4 py-4">
+    <div className="bg-background h-[calc(100vh-72px)] w-full space-y-4 overflow-y-scroll px-2.5 pt-2.5 pb-4">
       {/* Locked Course IDs Input */}
       <div>
         <Label className="text-muted-foreground text-xs font-bold">
@@ -388,14 +385,24 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
           INCLUDE HONORS
         </Label>
         <Switch
-          checked={(filters.minHonorsCourses ?? 0) > 0}
+          checked={(filters.includeHonors)}
           onCheckedChange={(checked) =>
-            updateFilter("minHonorsCourses", checked ? 1 : undefined)
+            updateFilter("includeHonors", checked)
           }
           className="data-[state=checked]:bg-red-500"
         />
       </div>
 
+      <Separator />
+
+      <div className="pb-20">
+        <FeedbackModal>
+          <div className="text-xs text-neu font-semibold cursor-pointer hover:underline">
+            Have an idea for a filter? Let us know <MoveRightIcon className="inline h-3 w-3"/>      
+          </div>
+        </FeedbackModal>
+      </div>
+      
     </div>
   );
 }

--- a/src/components/scheduler/SchedulerView.tsx
+++ b/src/components/scheduler/SchedulerView.tsx
@@ -206,9 +206,9 @@ export function SchedulerView({ schedules, totalSchedules, filters }: SchedulerV
             {filters.nupaths && filters.nupaths.length > 0 && (
               <span className="bg-white px-2 py-1 rounded">NUPaths: {filters.nupaths.join(", ")}</span>
             )}
-            {filters.isOnline !== undefined && (
+            {filters.includesOnline !== undefined && (
               <span className="bg-white px-2 py-1 rounded">
-                {filters.isOnline ? "Includes Online Courses" : "Excludes Online Courses"}
+                {filters.includesOnline ? "Includes Online Courses" : "Excludes Online Courses"}
               </span>
             )}
           </div>

--- a/src/components/scheduler/SchedulerView.tsx
+++ b/src/components/scheduler/SchedulerView.tsx
@@ -198,8 +198,10 @@ export function SchedulerView({ schedules, totalSchedules, filters }: SchedulerV
             {filters.minSeatsLeft !== undefined && (
               <span className="bg-white px-2 py-1 rounded">Min Seats: {filters.minSeatsLeft}</span>
             )}
-            {filters.minHonorsCourses !== undefined && (
-              <span className="bg-white px-2 py-1 rounded">Min Honors: {filters.minHonorsCourses}</span>
+            {filters.includeHonors !== undefined && (
+              <span className="bg-white px-2 py-1 rounded">
+                {filters.includeHonors ? "Includes Honors Courses" : "Excludes Honors Courses"}
+              </span>
             )}
             {filters.nupaths && filters.nupaths.length > 0 && (
               <span className="bg-white px-2 py-1 rounded">NUPaths: {filters.nupaths.join(", ")}</span>

--- a/src/components/scheduler/SchedulerView.tsx
+++ b/src/components/scheduler/SchedulerView.tsx
@@ -156,7 +156,7 @@ export function SchedulerView({ schedules, totalSchedules, filters }: SchedulerV
 
       {/* Schedule/Plan Tabs (Second Row) */}
       {displaySchedules.length > 0 && (
-        <div className="flex items-center gap-2 mb-4 overflow-x-auto pb-2">
+        <div className="flex items-center gap-2 mb-4 overflow-x-auto">
           {displaySchedules.map((schedule, index) => {
             const scheduleKey = getScheduleKey(schedule);
             return (
@@ -175,43 +175,6 @@ export function SchedulerView({ schedules, totalSchedules, filters }: SchedulerV
               </button>
             );
           })}
-        </div>
-      )}
-
-      {/* Active Filters Summary */}
-      {Object.keys(filters).length > 0 && (
-        <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-          <h2 className="text-sm font-semibold mb-1 text-blue-900">Active Filters:</h2>
-          <div className="flex flex-wrap gap-2 text-xs text-blue-800">
-            {filters.startTime && (
-              <span className="bg-white px-2 py-1 rounded">Earliest: {formatTime(filters.startTime)}</span>
-            )}
-            {filters.endTime && (
-              <span className="bg-white px-2 py-1 rounded">Latest: {formatTime(filters.endTime)}</span>
-            )}
-            {filters.specificDaysFree && filters.specificDaysFree.length > 0 && (
-              <span className="bg-white px-2 py-1 rounded">Days Free: {formatDays(filters.specificDaysFree)}</span>
-            )}
-            {filters.minDaysFree !== undefined && (
-              <span className="bg-white px-2 py-1 rounded">Min Days Free: {filters.minDaysFree}</span>
-            )}
-            {filters.minSeatsLeft !== undefined && (
-              <span className="bg-white px-2 py-1 rounded">Min Seats: {filters.minSeatsLeft}</span>
-            )}
-            {filters.includeHonors !== undefined && (
-              <span className="bg-white px-2 py-1 rounded">
-                {filters.includeHonors ? "Includes Honors Courses" : "Excludes Honors Courses"}
-              </span>
-            )}
-            {filters.nupaths && filters.nupaths.length > 0 && (
-              <span className="bg-white px-2 py-1 rounded">NUPaths: {filters.nupaths.join(", ")}</span>
-            )}
-            {filters.includesOnline !== undefined && (
-              <span className="bg-white px-2 py-1 rounded">
-                {filters.includesOnline ? "Includes Online Courses" : "Excludes Online Courses"}
-              </span>
-            )}
-          </div>
         </div>
       )}
 

--- a/src/components/scheduler/SchedulerView.tsx
+++ b/src/components/scheduler/SchedulerView.tsx
@@ -204,6 +204,11 @@ export function SchedulerView({ schedules, totalSchedules, filters }: SchedulerV
             {filters.nupaths && filters.nupaths.length > 0 && (
               <span className="bg-white px-2 py-1 rounded">NUPaths: {filters.nupaths.join(", ")}</span>
             )}
+            {filters.isOnline !== undefined && (
+              <span className="bg-white px-2 py-1 rounded">
+                {filters.isOnline ? "Includes Online Courses" : "Excludes Online Courses"}
+              </span>
+            )}
           </div>
         </div>
       )}

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -13,7 +13,7 @@ interface SchedulerWrapperProps {
 
 export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
   const router = useRouter();
-  const [filters, setFilters] = useState<ScheduleFilters>({isOnline: true});
+  const [filters, setFilters] = useState<ScheduleFilters>({isOnline: true, includeHonors: true});
   const [isPending, startTransition] = useTransition();
 
   const handleGenerateSchedules = async (lockedCourseIds: number[], optionalCourseIds: number[]) => {

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -13,7 +13,7 @@ interface SchedulerWrapperProps {
 
 export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
   const router = useRouter();
-  const [filters, setFilters] = useState<ScheduleFilters>({});
+  const [filters, setFilters] = useState<ScheduleFilters>({isOnline: true});
   const [isPending, startTransition] = useTransition();
 
   const handleGenerateSchedules = async (lockedCourseIds: number[], optionalCourseIds: number[]) => {

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -13,7 +13,7 @@ interface SchedulerWrapperProps {
 
 export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
   const router = useRouter();
-  const [filters, setFilters] = useState<ScheduleFilters>({isOnline: true, includeHonors: true});
+  const [filters, setFilters] = useState<ScheduleFilters>({includesOnline: true, includeHonors: true});
   const [isPending, startTransition] = useTransition();
 
   const handleGenerateSchedules = async (lockedCourseIds: number[], optionalCourseIds: number[]) => {

--- a/src/components/scheduler/TimeInput.tsx
+++ b/src/components/scheduler/TimeInput.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronDown } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+interface TimeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  startHour?: number;
+  endHour?: number;
+  intervalMinutes?: number;
+}
+
+function generateTimeOptions(
+  startHour: number,
+  endHour: number,
+  intervalMinutes: number
+): { value: string; label: string }[] {
+  const options: { value: string; label: string }[] = [];
+  
+  for (let hour = startHour; hour <= endHour; hour++) {
+    for (let minutes = 0; minutes < 60; minutes += intervalMinutes) {
+      // Skip times after the end hour
+      if (hour === endHour && minutes > 0) break;
+      
+      const timeValue = `${hour.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+      const isPM = hour >= 12;
+      const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
+      const label = `${displayHour}:${minutes.toString().padStart(2, "0")} ${isPM ? "PM" : "AM"}`;
+      
+      options.push({ value: timeValue, label });
+    }
+  }
+  
+  return options;
+}
+
+export function TimeInput({ 
+  value, 
+  onChange,
+  startHour = 6,
+  endHour = 24,
+  intervalMinutes = 15,
+}: TimeInputProps) {
+  const [open, setOpen] = useState(false);
+  
+  const timeOptions = generateTimeOptions(startHour, endHour, intervalMinutes);
+  
+  const selectedOption = timeOptions.find((option) => option.value === value);
+  const displayValue = selectedOption?.label || "-- : -- --";
+
+  return (      
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button className="flex w-20 items-center gap-2 bg-transparent font-medium text-muted-foreground hover:text-foreground/80 focus:outline-none">
+            <span className="inline-block w-14 text-left text-sm">{displayValue}</span>
+            <ChevronDown className="h-4 w-4 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[200px] p-0" align="end">
+          <Command>
+            <CommandInput placeholder="-- : --" />
+            <CommandList>
+              <CommandEmpty>No time found.</CommandEmpty>
+              <CommandGroup>
+                {timeOptions.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    value={option.label}
+                    onSelect={() => {
+                      onChange(option.value);
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={`mr-2 h-4 w-4 ${
+                        option.value === value ? "opacity-100" : "opacity-0"
+                      }`}
+                    />
+                    {option.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+  );
+}

--- a/src/lib/scheduler/filters.test.ts
+++ b/src/lib/scheduler/filters.test.ts
@@ -248,22 +248,22 @@ describe("filters", () => {
       );
     });
 
-    test("should filter by minHonorsCourses", () => {
+    test("should filter by including honors", () => {
       const schedule = [
         createMockSection({ honors: true }),
         createMockSection({ id: 2, crn: "20001", honors: true }),
         createMockSection({ id: 3, crn: "30001", honors: false }),
       ];
 
-      // Schedule has 2 honors courses, filter requires at least 2
+      // Schedule has 2 honors courses, filter requires at least 1
       assert.strictEqual(
-        schedulePassesFilters(schedule, { minHonorsCourses: 2 }),
+        schedulePassesFilters(schedule, { includeHonors: true }),
         true
       );
 
-      // Schedule has 2 honors courses, filter requires at least 3
+      // Schedule has 2 honor courses, filter requires none
       assert.strictEqual(
-        schedulePassesFilters(schedule, { minHonorsCourses: 3 }),
+        schedulePassesFilters(schedule, { includeHonors: false }),
         false
       );
     });
@@ -325,7 +325,7 @@ describe("filters", () => {
       assert.strictEqual(
         schedulePassesFilters(schedule, {
           minSeatsLeft: 5,
-          minHonorsCourses: 1,
+          includeHonors: true,
           startTime: 800,
         }),
         true
@@ -335,7 +335,7 @@ describe("filters", () => {
       assert.strictEqual(
         schedulePassesFilters(schedule, {
           minSeatsLeft: 15, // fails
-          minHonorsCourses: 1,
+          includeHonors: true,
           startTime: 800,
         }),
         false

--- a/src/lib/scheduler/filters.test.ts
+++ b/src/lib/scheduler/filters.test.ts
@@ -44,6 +44,30 @@ describe("filters", () => {
       assert.strictEqual(sectionPassesFilters(section, filters), true);
     });
 
+    test("should filter by including online courses", () => {
+      const onlineSection = createMockSection({
+        meetingTimes: [],
+        campus: "Online",
+      });
+
+      const inPersonSection = createMockSection({
+        meetingTimes: [
+          {
+            days: [1, 3],
+            startTime: 900,
+            endTime: 1030,
+            final: false,
+          },
+        ],
+        campus: "Boston",
+      });
+
+      assert.strictEqual(sectionPassesFilters(onlineSection, { includesOnline: true }), true);
+      assert.strictEqual(sectionPassesFilters(inPersonSection, { includesOnline: true }), true);
+      assert.strictEqual(sectionPassesFilters(onlineSection, { includesOnline: false }), false);
+      assert.strictEqual(sectionPassesFilters(inPersonSection, { includesOnline: false }), true);
+    })
+
     test("should filter by startTime", () => {
       const section = createMockSection({
         meetingTimes: [
@@ -265,6 +289,66 @@ describe("filters", () => {
       assert.strictEqual(
         schedulePassesFilters(schedule, { includeHonors: false }),
         false
+      );
+    });
+
+    test("should filter by including online courses", () => {
+      const onlineSection = createMockSection({
+        meetingTimes: [],
+        campus: "Online",
+      });
+      
+      const inPersonSection = createMockSection({
+        meetingTimes: [
+          {
+            days: [1, 3],
+            startTime: 900,
+            endTime: 1030,
+            final: false,
+          },
+        ],
+        campus: "Boston",
+      });
+
+      const section2 = createMockSection({ 
+        id: 2, 
+        crn: "20001", 
+        campus: "Boston", 
+        meetingTimes: [ 
+          {
+            days: [2,4],
+            startTime: 1100,
+            endTime: 1230,
+            final: false,
+          }
+        ] 
+      });
+
+      const scheduleWithOnline = [onlineSection, section2];
+      const scheduleWithoutOnline = [inPersonSection, section2];
+      
+      // Schedule has an online course, filter allows online courses
+      assert.strictEqual(
+        schedulePassesFilters(scheduleWithOnline, { includesOnline: true }),
+        true
+      );
+
+      // Schedule has an online course, filter excludes online courses
+      assert.strictEqual(
+        schedulePassesFilters(scheduleWithOnline, { includesOnline: false }),
+        false
+      );
+
+      // Schedule has no online courses, filter excludes online courses
+      assert.strictEqual(
+        schedulePassesFilters(scheduleWithoutOnline, { includesOnline: false }),
+        true
+      );
+
+      // Schedule has no online courses, filter allows online courses
+      assert.strictEqual(
+        schedulePassesFilters(scheduleWithoutOnline, { includesOnline: true }),
+        true
       );
     });
 

--- a/src/lib/scheduler/filters.ts
+++ b/src/lib/scheduler/filters.ts
@@ -15,7 +15,7 @@ export type ScheduleFilters = {
   minSeatsLeft?: number;
   includeHonors?: boolean;
   nupaths?: string[];
-  isOnline?: boolean;
+  includesOnline?: boolean;
 };
 
 // Helper function to check if a section conflicts with time constraints
@@ -82,6 +82,13 @@ export const sectionPassesFilters = (
     return false;
   }
 
+  // The only time we care is if we want to exclude online courses
+  if (filters.includesOnline == false) {
+    if (section.campus == "Online") {
+      return false;
+    }
+  }
+
   return true;
 };
 
@@ -117,18 +124,6 @@ const scheduleHasRequiredNupaths = (
   return requiredNupaths.every((nupath) => scheduleNupaths.has(nupath));
 };
 
-// Check if a schedule has at least one online course
-const scheduleHasOnlineCourse = (
-  schedule: SectionWithCourse[],
-): boolean => {
-  for (const section of schedule) {
-    if (section.campus == "Online") {
-      return true;
-    }
-  }
-  return false;
-};
-
 // Check if a complete schedule passes all filters
 export const schedulePassesFilters = (
   schedule: SectionWithCourse[],
@@ -161,13 +156,6 @@ export const schedulePassesFilters = (
   // Check NUPath requirements (only if provided)
   if (filters.nupaths && filters.nupaths.length > 0) {
     if (!scheduleHasRequiredNupaths(schedule, filters.nupaths)) {
-      return false;
-    }
-  }
-
-  // Check that at least no courses are online
-  if (filters.isOnline == false) {
-    if (scheduleHasOnlineCourse(schedule)) {
       return false;
     }
   }

--- a/src/lib/scheduler/filters.ts
+++ b/src/lib/scheduler/filters.ts
@@ -13,7 +13,7 @@ export type ScheduleFilters = {
   specificDaysFree?: number[]; // array of day numbers (0=Sunday, 1=Monday, 2=Tuesday, ..., 6=Saturday)
   minDaysFree?: number;
   minSeatsLeft?: number;
-  minHonorsCourses?: number;
+  includeHonors?: boolean;
   nupaths?: string[];
   isOnline?: boolean;
 };
@@ -150,10 +150,10 @@ export const schedulePassesFilters = (
     }
   }
 
-  // Check minimum honors courses (only if provided)
-  if (filters.minHonorsCourses !== undefined) {
+  // Check that no honors courses are included (only if specified)
+  if (filters.includeHonors == false) {
     const honorsCount = schedule.filter((section) => section.honors).length;
-    if (honorsCount < filters.minHonorsCourses) {
+    if (honorsCount > 0) {
       return false;
     }
   }

--- a/src/lib/scheduler/filters.ts
+++ b/src/lib/scheduler/filters.ts
@@ -15,6 +15,7 @@ export type ScheduleFilters = {
   minSeatsLeft?: number;
   minHonorsCourses?: number;
   nupaths?: string[];
+  isOnline?: boolean;
 };
 
 // Helper function to check if a section conflicts with time constraints
@@ -116,6 +117,18 @@ const scheduleHasRequiredNupaths = (
   return requiredNupaths.every((nupath) => scheduleNupaths.has(nupath));
 };
 
+// Check if a schedule has at least one online course
+const scheduleHasOnlineCourse = (
+  schedule: SectionWithCourse[],
+): boolean => {
+  for (const section of schedule) {
+    if (section.campus == "Online") {
+      return true;
+    }
+  }
+  return false;
+};
+
 // Check if a complete schedule passes all filters
 export const schedulePassesFilters = (
   schedule: SectionWithCourse[],
@@ -148,6 +161,13 @@ export const schedulePassesFilters = (
   // Check NUPath requirements (only if provided)
   if (filters.nupaths && filters.nupaths.length > 0) {
     if (!scheduleHasRequiredNupaths(schedule, filters.nupaths)) {
+      return false;
+    }
+  }
+
+  // Check that at least no courses are online
+  if (filters.isOnline == false) {
+    if (scheduleHasOnlineCourse(schedule)) {
       return false;
     }
   }


### PR DESCRIPTION
Implements the [new figma designs](https://www.figma.com/design/26YDVYhCcSghWEkHaYn3VO/%F0%9F%97%93%EF%B8%8F-PlanNEU-Wireframes?node-id=717-4829&t=pFe1ardY7l6BwGXR-0) for scheduler page filter bar and also fixes filtering by schedules that contain online courses.

TODO: 
- Styling with making the text not muted when selecting something.
- Validating time inputs to ensure valid start time and end time where the end time is after the start time. 
- Add info section for the free days part (need to brainstorm what should go in there)
- Style free days div to match figma