### PR TITLE
feat: Add course selection modal to catalog page

### DIFF
--- a/src/app/(app)/catalog/[term]/page.tsx
+++ b/src/app/(app)/catalog/[term]/page.tsx
@@ -1,13 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
 import { Searchskie } from "@/components/icons/Searchskie";
+import { Button } from "@/components/ui/button";
+import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
 
 export default function Page() {
+  const params = useParams();
+  const term = params?.term as string;
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
-    <div className="bg-neu1 grid h-full min-h-0 w-full place-content-center overflow-y-scroll rounded-lg rounded-b-none border border-b-0">
-      <div className="flex flex-col items-center gap-1 text-center">
-        <Searchskie className="w-72 pb-8" />
-        <h1 className="text-xl font-semibold">Looking for something?</h1>
-        <p className="">Select a course to see more of its information</p>
+    <>
+      <div className="bg-neu1 grid h-full min-h-0 w-full place-content-center overflow-y-scroll rounded-lg rounded-b-none border border-b-0">
+        <div className="flex flex-col items-center gap-1 text-center">
+          <Searchskie className="w-72 pb-8" />
+          <h1 className="text-xl font-semibold">Looking for something?</h1>
+          <p className="">Select a course to see more of its information</p>
+          <Button 
+            onClick={() => setIsModalOpen(true)}
+            className="mt-4"
+          >
+            Add Courses
+          </Button>
+        </div>
       </div>
-    </div>
+      
+      <AddCoursesModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        term={term || "Spring 2026"}
+      />
+    </>
   );
 }

--- a/src/app/(app)/catalog/[term]/page.tsx
+++ b/src/app/(app)/catalog/[term]/page.tsx
@@ -1,37 +1,15 @@
-"use client";
-
-import { useState } from "react";
-import { useParams } from "next/navigation";
 import { Searchskie } from "@/components/icons/Searchskie";
-import { Button } from "@/components/ui/button";
-import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
 
-export default function Page() {
-  const params = useParams();
-  const term = params?.term as string;
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
+export default async function Page() {
   return (
-    <>
-      <div className="bg-neu1 grid h-full min-h-0 w-full place-content-center overflow-y-scroll rounded-lg rounded-b-none border border-b-0">
-        <div className="flex flex-col items-center gap-1 text-center">
-          <Searchskie className="w-72 pb-8" />
-          <h1 className="text-xl font-semibold">Looking for something?</h1>
-          <p className="">Select a course to see more of its information</p>
-          <Button 
-            onClick={() => setIsModalOpen(true)}
-            className="mt-4"
-          >
-            Add Courses
-          </Button>
-        </div>
+    <div className="bg-neu1 grid h-full min-h-0 w-full place-content-center overflow-y-scroll rounded-lg rounded-b-none border border-b-0">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Searchskie className="w-72 pb-8" />
+        <h1 className="text-xl font-semibold">Looking for something?</h1>
+        <p className="text-muted-foreground text-sm">
+          Search for a course or use the scheduler to plan your semester
+        </p>
       </div>
-      
-      <AddCoursesModal
-        open={isModalOpen}
-        onOpenChange={setIsModalOpen}
-        term={term || "Spring 2026"}
-      />
-    </>
+    </div>
   );
 }

--- a/src/app/(app)/scheduler/page.tsx
+++ b/src/app/(app)/scheduler/page.tsx
@@ -1,7 +1,9 @@
 import { db } from "@/db";
-import { nupathsT } from "@/db/schema";
+import { nupathsT, coursesT } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import { generateSchedules } from "@/lib/scheduler/generateSchedules";
 import { SchedulerWrapper } from "@/components/scheduler/SchedulerWrapper";
+import { getTermName } from "@/lib/controllers/getTerms";
 
 export default async function Page({
   searchParams,
@@ -19,6 +21,30 @@ export default async function Page({
   // Generate schedules if course IDs are provided
   const allSchedules = courseIds.length > 0 ? await generateSchedules(courseIds) : [];
 
+  // Get term from first course to show term name, or use default
+  let term = "202630";
+  let termName = "Spring 2026";
+  
+  if (courseIds.length > 0) {
+    const firstCourse = await db
+      .select({ term: coursesT.term })
+      .from(coursesT)
+      .where(eq(coursesT.id, courseIds[0]))
+      .limit(1);
+    
+    term = firstCourse[0]?.term || "202630";
+    termName = await getTermName(term);
+  } else {
+    // Get the current term - fetch from the first course or use a default
+    const firstCourse = await db
+      .select({ term: coursesT.term })
+      .from(coursesT)
+      .limit(1);
+    
+    term = firstCourse[0]?.term || "202630";
+    termName = await getTermName(term);
+  }
+
   // Fetch available NUPath options
   const nupathOptions = await db
     .selectDistinct({ short: nupathsT.short, name: nupathsT.name})
@@ -27,7 +53,12 @@ export default async function Page({
 
   return (
     <div className="bg-secondary h-full w-full px-4 pt-4 xl:px-6">
-      <SchedulerWrapper initialSchedules={allSchedules} nupathOptions={nupathOptions} />
+      <SchedulerWrapper 
+        initialSchedules={allSchedules} 
+        nupathOptions={nupathOptions}
+        term={term}
+        termName={termName}
+      />
     </div>
   );
 }

--- a/src/components/catalog/AddCoursesWithModal.tsx
+++ b/src/components/catalog/AddCoursesWithModal.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
+
+export function AddCoursesWithModal({
+  term,
+  termName,
+}: {
+  term: string;
+  termName: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)} className="mt-4">
+        Add Courses
+      </Button>
+
+      <AddCoursesModal
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        term={term}
+        termName={termName}
+      />
+    </>
+  );
+}
+

--- a/src/components/navigation/NavBar.tsx
+++ b/src/components/navigation/NavBar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Bookmark, CircleQuestionMark, DoorOpen } from "lucide-react";
+import { Bookmark, CircleQuestionMark, DoorOpen, Calendar } from "lucide-react";
 import { use } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -47,9 +47,10 @@ export function NavBar({
         <Link
           href="/scheduler"
           data-active={pathname === "/scheduler"}
-          className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center rounded-full border-1 p-2 text-sm"
+          className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center gap-2 rounded-full border-1 px-4 py-2 text-sm"
         >
-          Scheduler
+          <Calendar className="size-4" />
+          <span>Scheduler</span>
         </Link>
       )}
       {faqFlag && (

--- a/src/components/scheduler/AddCourseModal.tsx
+++ b/src/components/scheduler/AddCourseModal.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useDeferredValue, Suspense, use, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   X,
   Search,
@@ -14,20 +15,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/cn";
+import type { CourseSearchResult } from "@/lib/types";
 
 interface Course {
   id: number;
   code: string;
   name: string;
-}
-
-interface SearchResult {
-  id: number;
-  name: string;
-  subject: string;
-  courseNumber: string;
-  campus: string[];
-  [key: string]: unknown;
 }
 
 interface SelectedCourse {
@@ -38,154 +31,43 @@ interface SelectedCourse {
   isLocked?: boolean;
 }
 
-interface AddCoursesModalProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  term?: string;
-  onGenerateSchedules?: (courseIds: number[]) => void;
+// this acts as a single value cache for the data fetcher - the fetch promise has to be stored outside
+// the react tree since otherwise they would be recreated on every rerender
+let cacheKey = "!";
+let cachePromise: Promise<unknown> = new Promise((r) => r([]));
+
+function fetcher<T>(key: string, p: () => string) {
+  if (!Object.is(cacheKey, key)) {
+    cacheKey = key;
+    // if window is undefined, then we are ssr and thus cannot do a relative fetch
+    if (typeof window !== "undefined") {
+      // PERF: next caching on the fetch
+      cachePromise = fetch(p()).then((r) => r.json());
+    }
+  }
+
+  return cachePromise as Promise<T>;
 }
 
 export function AddCoursesModal({
   open,
   onOpenChange,
   term = "Spring 2026",
+  termName = "Spring 2026",
   onGenerateSchedules,
-}: AddCoursesModalProps) {
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  term?: string;
+  termName?: string;
+  onGenerateSchedules?: (courseIds: number[]) => void;
+}) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCourses, setSelectedCourses] = useState<SelectedCourse[]>([]);
   const [campus, setCampus] = useState("Boston Campus");
-  const [courses, setCourses] = useState<Course[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [termDisplayName, setTermDisplayName] = useState<string | null>(null);
-
-  // Debounced search query - use useEffect with timeout for debouncing
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setDebouncedSearchQuery(searchQuery);
-    }, 300);
-    return () => clearTimeout(timeoutId);
-  }, [searchQuery]);
-
-  // Fetch term display name
-  useEffect(() => {
-    const fetchTermName = async () => {
-      if (!term) {
-        setTermDisplayName(null);
-        return;
-      }
-
-      try {
-        const response = await fetch("/api/terms");
-        if (!response.ok) {
-          console.warn("Failed to fetch terms for display name");
-          setTermDisplayName(term); // Fallback to term ID
-          return;
-        }
-
-        const groupedTerms: {
-          neu: Array<{ term: string; name: string }>;
-          cps: Array<{ term: string; name: string }>;
-          law: Array<{ term: string; name: string }>;
-        } = await response.json();
-
-        // Search through all term groups to find matching term
-        const allTerms = [
-          ...groupedTerms.neu,
-          ...groupedTerms.cps,
-          ...groupedTerms.law,
-        ];
-
-        const foundTerm = allTerms.find((t) => t.term === term);
-        setTermDisplayName(foundTerm?.name || term);
-      } catch (err) {
-        console.warn("Error fetching term name:", err);
-        setTermDisplayName(term); // Fallback to term ID
-      }
-    };
-
-    fetchTermName();
-  }, [term]);
-
-  // Fetch courses from API
-  useEffect(() => {
-    const fetchCourses = async () => {
-      // Don't fetch if no term is provided
-      if (!term) {
-        setCourses([]);
-        setIsLoading(false);
-        setError("Term is required");
-        return;
-      }
-
-      // Skip search if query is less than 4 characters (API requirement)
-      if (debouncedSearchQuery.length > 0 && debouncedSearchQuery.length < 4) {
-        setCourses([]);
-        setIsLoading(false);
-        return;
-      }
-
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const params = new URLSearchParams();
-        params.set("term", term);
-        if (debouncedSearchQuery) {
-          params.set("q", debouncedSearchQuery);
-        }
-        // TODO: Add campus filter when campus filtering is implemented
-        // if (campus && campus !== "Boston Campus") {
-        //   params.append("camp", campus);
-        // }
-
-        const response = await fetch(`/api/search?${params.toString()}`);
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch courses: ${response.statusText}`);
-        }
-
-        const data: SearchResult[] | { error: string } = await response.json();
-
-        if ("error" in data) {
-          setError(data.error);
-          setCourses([]);
-          return;
-        }
-
-        // Transform API response to Course format
-        const transformedCourses: Course[] = data.map((result) => ({
-          id: result.id,
-          code: `${result.subject} ${result.courseNumber}`,
-          name: result.name,
-        }));
-
-        // Remove duplicates based on course code
-        const uniqueCourses = Array.from(
-          new Map(
-            transformedCourses.map((course) => [course.code, course]),
-          ).values(),
-        );
-
-        setCourses(uniqueCourses);
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to fetch courses",
-        );
-        setCourses([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchCourses();
-  }, [debouncedSearchQuery, term, campus]);
-
-  // Filter courses based on search (already done by API, but we can add client-side filtering if needed)
-  const filteredCourses = courses;
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const isStale = deferredSearchQuery !== searchQuery;
 
   const handleCourseSelect = (course: Course) => {
     if (isSelected(course.code)) {
@@ -258,10 +140,7 @@ export function AddCoursesModal({
             </h2>
             <p className="text-muted-foreground mt-1 text-sm">
               Add up to 10 courses that you are considering for{" "}
-              <span className="text-foreground font-medium">
-                {termDisplayName || term}
-              </span>
-              .
+              <span className="text-foreground font-medium">{termName}</span>.
             </p>
           </div>
           <button
@@ -295,120 +174,299 @@ export function AddCoursesModal({
             </div>
 
             {/* Course List - Added click handler and selection styling */}
-            <div className="border-border max-h-72 space-y-1 overflow-y-auto rounded-lg border">
-              {isLoading ? (
-                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
-                  Loading courses...
-                </div>
-              ) : error ? (
-                <div className="text-muted-foreground flex h-full flex-col items-center justify-center py-12 text-sm">
-                  <p className="text-destructive">Error: {error}</p>
-                </div>
-              ) : searchQuery.length > 0 && searchQuery.length < 4 ? (
-                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
-                  Type at least 4 characters to search
-                </div>
-              ) : filteredCourses.length === 0 ? (
-                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
-                  {searchQuery
-                    ? "No courses found"
-                    : "Start typing to search for courses"}
-                </div>
-              ) : (
-                filteredCourses.map((course) => (
-                  <button
-                    key={course.code}
-                    onClick={() => handleCourseSelect(course)}
-                    className={cn(
-                      "hover:bg-muted/50 flex w-full items-baseline gap-2 px-4 py-2.5 text-left transition-colors",
-                      isSelected(course.code) && "bg-muted/30",
-                    )}
-                  >
-                    <span className="text-foreground text-sm font-medium">
-                      {course.code}
-                    </span>
-                    <span className="text-muted-foreground text-sm">
-                      {course.name}
-                    </span>
-                  </button>
-                ))
+            <div
+              className={cn(
+                "border-border rounded-lg border transition-opacity",
+                isStale && "opacity-60",
               )}
+            >
+              <Suspense fallback={<CourseListSkeleton />}>
+                <CourseList
+                  searchQuery={deferredSearchQuery}
+                  term={term || ""}
+                  campus={campus}
+                  selectedCourses={selectedCourses}
+                  onCourseSelect={handleCourseSelect}
+                  isSelected={isSelected}
+                />
+              </Suspense>
             </div>
           </div>
 
           {/* Right Column - Selected Courses - Now uses state instead of static data */}
-          <div className="border-border max-h-96 overflow-y-auto rounded-lg border">
-            {selectedCourses.length === 0 ? (
-              <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
-                No courses selected
-              </div>
-            ) : (
-              selectedCourses.map((course, index) => (
-                <div key={course.code + index}>
-                  {/* Parent Course */}
-                  <div className="group hover:bg-muted/50 flex items-center gap-2 px-4 py-2.5 transition-colors">
-                    <button
-                      onClick={() => handleToggleLock(course.code)}
-                      className="text-muted-foreground hover:text-foreground shrink-0"
-                    >
-                      {course.isLocked ? (
-                        <Lock className="h-4 w-4" />
-                      ) : (
-                        <LockOpen className="h-4 w-4" />
-                      )}
-                    </button>
-                    <div className="min-w-0 flex-1">
-                      <span className="text-foreground text-sm font-medium">
-                        {course.code}
-                      </span>
-                      <span className="text-muted-foreground ml-2 truncate text-sm">
-                        {course.name}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-                      <button className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1">
-                        <Info className="h-4 w-4" />
-                      </button>
-                      <button
-                        onClick={() => handleRemove(course.code)}
-                        className="text-muted-foreground hover:bg-muted hover:text-destructive rounded p-1"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Child Courses (Recitations/Labs) */}
-                  {course.children.map((child) => (
-                    <div
-                      key={child.code}
-                      className="hover:bg-muted/50 flex items-center gap-2 py-2.5 pr-4 pl-10 transition-colors"
-                    >
-                      <span className="text-muted-foreground text-sm font-medium">
-                        {child.code}
-                      </span>
-                      <span className="text-muted-foreground text-sm">
-                        {child.name}
-                      </span>
-                    </div>
-                  ))}
+          <div className="flex flex-col gap-3">
+            <div className="border-border max-h-96 overflow-y-auto rounded-lg border bg-muted/20 p-2">
+              {selectedCourses.length === 0 ? (
+                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
+                  No courses selected
                 </div>
-              ))
-            )}
+              ) : (
+                selectedCourses.map((course, index) => (
+                  <div
+                    key={course.code + index}
+                    className="group mb-2 flex flex-col rounded-lg border bg-white p-3 shadow-sm transition-all hover:shadow-md"
+                  >
+                    {/* Parent Course */}
+                    <div className="flex items-start gap-2">
+                      <button
+                        onClick={() => handleToggleLock(course.code)}
+                        className="text-muted-foreground hover:text-foreground mt-0.5 shrink-0 transition-colors"
+                        title={course.isLocked ? "Unlock course" : "Lock course"}
+                      >
+                        {course.isLocked ? (
+                          <Lock className="h-4 w-4" />
+                        ) : (
+                          <LockOpen className="h-4 w-4" />
+                        )}
+                      </button>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-2">
+                          <span className="text-foreground text-sm font-bold">
+                            {course.code}
+                          </span>
+                          {course.isLocked && (
+                            <span className="text-muted-foreground text-xs">
+                              Locked
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-muted-foreground mt-0.5 text-left text-sm leading-tight">
+                          {course.name}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                        <button
+                          className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1.5 transition-colors"
+                          title="Course info"
+                        >
+                          <Info className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={() => handleRemove(course.code)}
+                          className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive rounded p-1.5 transition-colors"
+                          title="Remove course"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Child Courses (Recitations/Labs) */}
+                    {course.children.length > 0 && (
+                      <div className="mt-2 space-y-1 border-t pt-2">
+                        {course.children.map((child) => (
+                          <div
+                            key={child.code}
+                            className="bg-muted/30 flex items-center gap-2 rounded px-2 py-1.5"
+                          >
+                            <span className="text-foreground text-xs font-medium">
+                              {child.code}
+                            </span>
+                            <span className="text-muted-foreground truncate text-xs">
+                              {child.name}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+
+            {/* Generate Schedules Button */}
+            <Button
+              className="w-full"
+              onClick={handleGenerateSchedules}
+              disabled={selectedCourses.length === 0}
+            >
+              Generate Schedules
+            </Button>
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
 
-        {/* Footer - Button now calls handler and is disabled when no selection */}
-        <div className="p-6 pt-2">
-          <Button
-            className="w-full"
-            onClick={handleGenerateSchedules}
-            disabled={selectedCourses.length === 0}
-          >
-            Generate Schedules
-          </Button>
+function CourseList({
+  searchQuery,
+  term,
+  campus,
+  selectedCourses,
+  onCourseSelect,
+  isSelected,
+}: {
+  searchQuery: string;
+  term: string;
+  campus: string;
+  selectedCourses: SelectedCourse[];
+  onCourseSelect: (course: Course) => void;
+  isSelected: (courseCode: string) => boolean;
+}) {
+  // Handle empty states before using hooks
+  if (!searchQuery) {
+    return (
+      <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+        Start typing to search for courses
+      </div>
+    );
+  }
+
+  if (searchQuery.length > 0 && searchQuery.length < 4) {
+    return (
+      <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+        Type at least 4 characters to search
+      </div>
+    );
+  }
+
+  return (
+    <CourseListContent
+      searchQuery={searchQuery}
+      term={term}
+      campus={campus}
+      selectedCourses={selectedCourses}
+      onCourseSelect={onCourseSelect}
+      isSelected={isSelected}
+    />
+  );
+}
+
+function CourseListContent({
+  searchQuery,
+  term,
+  campus,
+  selectedCourses,
+  onCourseSelect,
+  isSelected,
+}: {
+  searchQuery: string;
+  term: string;
+  campus: string;
+  selectedCourses: SelectedCourse[];
+  onCourseSelect: (course: Course) => void;
+  isSelected: (courseCode: string) => boolean;
+}) {
+  const results = use(
+    fetcher<CourseSearchResult[] | { error: string }>(
+      searchQuery + term + campus,
+      () => {
+        const params = new URLSearchParams();
+        params.set("term", term);
+        params.set("q", searchQuery);
+        // TODO: Add campus filter when campus filtering is implemented
+        // if (campus && campus !== "Boston Campus") {
+        //   params.append("camp", campus);
+        // }
+        return `/api/search?${params.toString()}`;
+      },
+    ),
+  );
+
+  if (!Array.isArray(results)) {
+    if (results.error === "insufficient query length") {
+      return (
+        <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+          Type at least 4 characters to search
+        </div>
+      );
+    }
+
+    return (
+      <div className="text-muted-foreground flex h-72 flex-col items-center justify-center text-sm">
+        <p className="text-destructive">Error: {results.error}</p>
+      </div>
+    );
+  }
+
+  // Transform API response to Course format
+  const courses: Course[] = results.map((result) => ({
+    id: result.id,
+    code: `${result.subject} ${result.courseNumber}`,
+    name: result.name,
+  }));
+
+  if (courses.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+        No courses found
+      </div>
+    );
+  }
+
+  const parentRef = useRef(null);
+
+  const virtual = useVirtualizer({
+    count: courses.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 60, // Approximate height of each course item
+    scrollPaddingStart: 8,
+    overscan: 5,
+  });
+
+  const items = virtual.getVirtualItems();
+
+  return (
+    <div ref={parentRef} className="h-72 w-full overflow-y-auto p-2">
+      <div className="relative" style={{ height: virtual.getTotalSize() }}>
+        <div
+          className="absolute top-0 left-0 w-full"
+          style={{
+            transform: `translateY(${items[0]?.start ?? 0}px)`,
+          }}
+        >
+          {items.map((virtualItem) => {
+            const course = courses[virtualItem.index];
+            const selected = isSelected(course.code);
+            return (
+              <button
+                key={virtualItem.key}
+                data-index={virtualItem.index}
+                ref={virtual.measureElement}
+                onClick={() => onCourseSelect(course)}
+                className={cn(
+                  "mb-2 flex w-full flex-col rounded-lg border bg-white p-3 text-left shadow-sm transition-all",
+                  "hover:shadow-md hover:border-primary/50",
+                  selected
+                    ? "border-primary bg-primary/5 ring-2 ring-primary/20"
+                    : "border-border",
+                )}
+              >
+                <div className="flex items-baseline gap-2">
+                  <span className="text-foreground text-sm font-bold">
+                    {course.code}
+                  </span>
+                  {selected && (
+                    <span className="text-primary text-xs font-medium">
+                      Selected
+                    </span>
+                  )}
+                </div>
+                <span className="text-muted-foreground mt-0.5 text-sm">
+                  {course.name}
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
+    </div>
+  );
+}
+
+function CourseListSkeleton() {
+  return (
+    <div className="h-72 space-y-2 overflow-y-clip p-2">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="h-14 w-full animate-pulse rounded-lg border bg-white p-3"
+        >
+          <div className="bg-muted mb-1.5 h-4 w-24 rounded"></div>
+          <div className="bg-muted h-3 w-full rounded"></div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/scheduler/AddCourseModal.tsx
+++ b/src/components/scheduler/AddCourseModal.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import {
+  X,
+  Search,
+  Lock,
+  LockOpen,
+  Info,
+  Trash2,
+  ChevronDown,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/cn";
+
+interface Course {
+  id: number;
+  code: string;
+  name: string;
+}
+
+interface SearchResult {
+  id: number;
+  name: string;
+  subject: string;
+  courseNumber: string;
+  campus: string[];
+  [key: string]: unknown;
+}
+
+interface SelectedCourse {
+  id?: number;
+  code: string;
+  name: string;
+  children: Course[];
+  isLocked?: boolean;
+}
+
+interface AddCoursesModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  term?: string;
+  onGenerateSchedules?: (courseIds: number[]) => void;
+}
+
+export function AddCoursesModal({
+  open,
+  onOpenChange,
+  term = "Spring 2026",
+  onGenerateSchedules,
+}: AddCoursesModalProps) {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCourses, setSelectedCourses] = useState<SelectedCourse[]>([]);
+  const [campus, setCampus] = useState("Boston Campus");
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [termDisplayName, setTermDisplayName] = useState<string | null>(null);
+
+  // Debounced search query - use useEffect with timeout for debouncing
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, 300);
+    return () => clearTimeout(timeoutId);
+  }, [searchQuery]);
+
+  // Fetch term display name
+  useEffect(() => {
+    const fetchTermName = async () => {
+      if (!term) {
+        setTermDisplayName(null);
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/terms");
+        if (!response.ok) {
+          console.warn("Failed to fetch terms for display name");
+          setTermDisplayName(term); // Fallback to term ID
+          return;
+        }
+
+        const groupedTerms: {
+          neu: Array<{ term: string; name: string }>;
+          cps: Array<{ term: string; name: string }>;
+          law: Array<{ term: string; name: string }>;
+        } = await response.json();
+
+        // Search through all term groups to find matching term
+        const allTerms = [
+          ...groupedTerms.neu,
+          ...groupedTerms.cps,
+          ...groupedTerms.law,
+        ];
+
+        const foundTerm = allTerms.find((t) => t.term === term);
+        setTermDisplayName(foundTerm?.name || term);
+      } catch (err) {
+        console.warn("Error fetching term name:", err);
+        setTermDisplayName(term); // Fallback to term ID
+      }
+    };
+
+    fetchTermName();
+  }, [term]);
+
+  // Fetch courses from API
+  useEffect(() => {
+    const fetchCourses = async () => {
+      // Don't fetch if no term is provided
+      if (!term) {
+        setCourses([]);
+        setIsLoading(false);
+        setError("Term is required");
+        return;
+      }
+
+      // Skip search if query is less than 4 characters (API requirement)
+      if (debouncedSearchQuery.length > 0 && debouncedSearchQuery.length < 4) {
+        setCourses([]);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const params = new URLSearchParams();
+        params.set("term", term);
+        if (debouncedSearchQuery) {
+          params.set("q", debouncedSearchQuery);
+        }
+        // TODO: Add campus filter when campus filtering is implemented
+        // if (campus && campus !== "Boston Campus") {
+        //   params.append("camp", campus);
+        // }
+
+        const response = await fetch(`/api/search?${params.toString()}`);
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch courses: ${response.statusText}`);
+        }
+
+        const data: SearchResult[] | { error: string } = await response.json();
+
+        if ("error" in data) {
+          setError(data.error);
+          setCourses([]);
+          return;
+        }
+
+        // Transform API response to Course format
+        const transformedCourses: Course[] = data.map((result) => ({
+          id: result.id,
+          code: `${result.subject} ${result.courseNumber}`,
+          name: result.name,
+        }));
+
+        // Remove duplicates based on course code
+        const uniqueCourses = Array.from(
+          new Map(
+            transformedCourses.map((course) => [course.code, course]),
+          ).values(),
+        );
+
+        setCourses(uniqueCourses);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to fetch courses",
+        );
+        setCourses([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCourses();
+  }, [debouncedSearchQuery, term, campus]);
+
+  // Filter courses based on search (already done by API, but we can add client-side filtering if needed)
+  const filteredCourses = courses;
+
+  const handleCourseSelect = (course: Course) => {
+    if (isSelected(course.code)) {
+      setSelectedCourses((prev) => prev.filter((c) => c.code !== course.code));
+    } else if (selectedCourses.length < 10) {
+      setSelectedCourses((prev) => [
+        ...prev,
+        {
+          id: course.id,
+          code: course.code,
+          name: course.name,
+          children: [],
+          isLocked: false,
+        },
+      ]);
+    }
+  };
+
+  const handleToggleLock = (courseCode: string) => {
+    setSelectedCourses((prev) =>
+      prev.map((course) =>
+        course.code === courseCode
+          ? { ...course, isLocked: !course.isLocked }
+          : course,
+      ),
+    );
+  };
+
+  const handleRemove = (courseCode: string) => {
+    setSelectedCourses((prev) => prev.filter((c) => c.code !== courseCode));
+  };
+
+  const handleGenerateSchedules = () => {
+    const courseIds = selectedCourses
+      .map((course) => course.id)
+      .filter((id): id is number => id !== undefined);
+
+    if (courseIds.length === 0) {
+      console.warn(
+        "No course IDs available. Selected courses:",
+        selectedCourses,
+      );
+      alert("Unable to generate schedules: course IDs are missing.");
+      return;
+    }
+
+    if (onGenerateSchedules) {
+      onGenerateSchedules(courseIds);
+    } else {
+      router.push(`/scheduler?courseIds=${courseIds.join(",")}`);
+    }
+
+    onOpenChange(false);
+  };
+
+  const isSelected = (courseCode: string): boolean => {
+    return selectedCourses.some((course) => course.code === courseCode);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background relative w-full max-w-3xl rounded-xl shadow-2xl">
+        {/* Header */}
+        <div className="flex items-start justify-between p-6 pb-2">
+          <div className="flex-1 text-center">
+            <h2 className="text-foreground text-2xl font-semibold">
+              Add Courses
+            </h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Add up to 10 courses that you are considering for{" "}
+              <span className="text-foreground font-medium">
+                {termDisplayName || term}
+              </span>
+              .
+            </p>
+          </div>
+          <button
+            onClick={() => onOpenChange(false)}
+            className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-4 right-4 rounded-sm p-1 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="grid grid-cols-2 gap-4 p-6 pt-4">
+          {/* Left Column - Search */}
+          <div className="flex flex-col gap-3">
+            {/* Campus Dropdown */}
+            <button className="border-border bg-background hover:bg-muted/50 flex items-center justify-between rounded-lg border px-4 py-2.5 text-left transition-colors">
+              <span className="text-primary text-sm font-medium">{campus}</span>
+              <ChevronDown className="text-primary h-4 w-4" />
+            </button>
+
+            {/* Search Input */}
+            <div className="relative">
+              <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+              <Input
+                type="text"
+                placeholder="Search by course number or course name"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            {/* Course List - Added click handler and selection styling */}
+            <div className="border-border max-h-72 space-y-1 overflow-y-auto rounded-lg border">
+              {isLoading ? (
+                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
+                  Loading courses...
+                </div>
+              ) : error ? (
+                <div className="text-muted-foreground flex h-full flex-col items-center justify-center py-12 text-sm">
+                  <p className="text-destructive">Error: {error}</p>
+                </div>
+              ) : searchQuery.length > 0 && searchQuery.length < 4 ? (
+                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
+                  Type at least 4 characters to search
+                </div>
+              ) : filteredCourses.length === 0 ? (
+                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
+                  {searchQuery
+                    ? "No courses found"
+                    : "Start typing to search for courses"}
+                </div>
+              ) : (
+                filteredCourses.map((course) => (
+                  <button
+                    key={course.code}
+                    onClick={() => handleCourseSelect(course)}
+                    className={cn(
+                      "hover:bg-muted/50 flex w-full items-baseline gap-2 px-4 py-2.5 text-left transition-colors",
+                      isSelected(course.code) && "bg-muted/30",
+                    )}
+                  >
+                    <span className="text-foreground text-sm font-medium">
+                      {course.code}
+                    </span>
+                    <span className="text-muted-foreground text-sm">
+                      {course.name}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Right Column - Selected Courses - Now uses state instead of static data */}
+          <div className="border-border max-h-96 overflow-y-auto rounded-lg border">
+            {selectedCourses.length === 0 ? (
+              <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
+                No courses selected
+              </div>
+            ) : (
+              selectedCourses.map((course, index) => (
+                <div key={course.code + index}>
+                  {/* Parent Course */}
+                  <div className="group hover:bg-muted/50 flex items-center gap-2 px-4 py-2.5 transition-colors">
+                    <button
+                      onClick={() => handleToggleLock(course.code)}
+                      className="text-muted-foreground hover:text-foreground shrink-0"
+                    >
+                      {course.isLocked ? (
+                        <Lock className="h-4 w-4" />
+                      ) : (
+                        <LockOpen className="h-4 w-4" />
+                      )}
+                    </button>
+                    <div className="min-w-0 flex-1">
+                      <span className="text-foreground text-sm font-medium">
+                        {course.code}
+                      </span>
+                      <span className="text-muted-foreground ml-2 truncate text-sm">
+                        {course.name}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                      <button className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1">
+                        <Info className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => handleRemove(course.code)}
+                        className="text-muted-foreground hover:bg-muted hover:text-destructive rounded p-1"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Child Courses (Recitations/Labs) */}
+                  {course.children.map((child) => (
+                    <div
+                      key={child.code}
+                      className="hover:bg-muted/50 flex items-center gap-2 py-2.5 pr-4 pl-10 transition-colors"
+                    >
+                      <span className="text-muted-foreground text-sm font-medium">
+                        {child.code}
+                      </span>
+                      <span className="text-muted-foreground text-sm">
+                        {child.name}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Footer - Button now calls handler and is disabled when no selection */}
+        <div className="p-6 pt-2">
+          <Button
+            className="w-full"
+            onClick={handleGenerateSchedules}
+            disabled={selectedCourses.length === 0}
+          >
+            Generate Schedules
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { type SectionWithCourse } from "@/lib/scheduler/filters";
+import { type CourseColor, getSectionColor } from "@/lib/scheduler/courseColors";
+
+interface CalendarViewProps {
+  schedule: SectionWithCourse[];
+  scheduleNumber: number;
+  colorMap: Map<string, CourseColor>;
+}
+
+// Height per hour in pixels - increase this to make rows taller
+const HOUR_HEIGHT = 100;
+
+// Helper to convert time format (e.g., 1330 -> "1:30 PM")
+function formatTime(time: number): string {
+  const hours = Math.floor(time / 100);
+  const minutes = time % 100;
+  const period = hours >= 12 ? "PM" : "AM";
+  const displayHours = hours > 12 ? hours - 12 : hours === 0 ? 12 : hours;
+  return `${displayHours}:${minutes.toString().padStart(2, "0")} ${period}`;
+}
+
+// Convert military time to minutes from midnight for positioning
+function timeToMinutes(time: number): number {
+  const hours = Math.floor(time / 100);
+  const minutes = time % 100;
+  return hours * 60 + minutes;
+}
+
+export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarViewProps) {
+  const calendarRef = useRef<HTMLDivElement>(null);
+  
+  // Define time range (6 AM to midnight)
+  const startHour = 6;
+  const endHour = 24;
+  const totalHours = endHour - startHour;
+  
+  // Calculate minimum height based on hour height
+  const minCalendarHeight = totalHours * HOUR_HEIGHT;
+  
+  // Separate async/remote courses from scheduled courses
+  const asyncCourses = schedule.filter(section => 
+    !section.meetingTimes || 
+    section.meetingTimes.length === 0 || 
+    section.meetingTimes.every(mt => !mt.days || mt.days.length === 0)
+  );
+  
+  const scheduledCourses = schedule.filter(section => 
+    section.meetingTimes && 
+    section.meetingTimes.length > 0 && 
+    section.meetingTimes.some(mt => mt.days && mt.days.length > 0)
+  );
+  
+  // Auto-scroll to 7 AM on mount or when schedule changes
+  useEffect(() => {
+    if (calendarRef.current) {
+      const asyncHeaderHeight = asyncCourses.length > 0 ? 80 : 0;
+      const scrollPosition = 1 * HOUR_HEIGHT + 48 + asyncHeaderHeight + 8; // 7 AM is now 1 hour from start (6 AM)
+      calendarRef.current.scrollTop = scrollPosition;
+    }
+  }, [scheduleNumber, asyncCourses.length]);
+  
+  // Define days
+  const days = [
+    { short: "SUN", full: "SUNDAY", index: 0 },
+    { short: "MON", full: "MONDAY", index: 1 },
+    { short: "TUE", full: "TUESDAY", index: 2 },
+    { short: "WED", full: "WEDNESDAY", index: 3 },
+    { short: "THU", full: "THURSDAY", index: 4 },
+    { short: "FRI", full: "FRIDAY", index: 5 },
+    { short: "SAT", full: "SATURDAY", index: 6 },
+  ];
+
+  // Create time slots
+  const timeSlots: string[] = [];
+  for (let hour = startHour; hour < endHour; hour++) {
+    const period = hour >= 12 ? "PM" : "AM";
+    const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
+    timeSlots.push(`${displayHour} ${period}`);
+  }
+
+  // Calculate position for a class block
+  const getClassPosition = (startTime: number, endTime: number) => {
+    const startMinutes = timeToMinutes(startTime);
+    const endMinutes = timeToMinutes(endTime);
+    const startOfDay = startHour * 60;
+    const totalMinutes = totalHours * 60;
+
+    const top = ((startMinutes - startOfDay) / totalMinutes) * 100;
+    const height = ((endMinutes - startMinutes) / totalMinutes) * 100;
+
+    return { top: `${top}%`, height: `${height}%` };
+  };
+
+  return (
+    <div 
+      ref={calendarRef}
+      className="h-full w-full rounded-lg border border-gray-300 bg-white overflow-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
+    >
+      {/* Calendar Grid */}
+      <div className="relative">
+        {/* Sticky Header Row - spans all columns */}
+        <div className="sticky top-0 bg-white z-30 grid grid-cols-[65px_repeat(7,1fr)]">
+          {/* Time Column Header */}
+          <div className="bg-white">
+            {!asyncCourses.length && (
+              <div className="h-12 flex items-center justify-end pr-2 pb-1 text-sm font-semibold text-neu4">
+                GMT-5
+              </div>
+            )}
+          </div>
+          
+          {/* Day Headers */}
+          {days.map((day) => (
+            <div key={day.index} className="h-12 flex items-center justify-center pb-1 bg-white">
+              <div className="text-sm font-semibold text-neu6">{day.full}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Async/Remote Courses Section - spans all day columns */}
+        {asyncCourses.length > 0 && (
+          <div className="sticky top-12 bg-white z-30 grid grid-cols-[65px_1fr] border-b border-gray-200">
+            <div className="bg-white flex items-start justify-end pr-2 py-2">
+              <div className="text-sm font-semibold text-neu4 h-[39px] flex items-center">GMT-5</div>
+            </div>
+            <div className="py-2 px-1 space-y-2">
+              {asyncCourses.map((section, index) => {
+                const sectionColor = getSectionColor(section, colorMap);
+                return (
+                  <div
+                    key={index}
+                    className="rounded-md p-2 px-3 flex items-center gap-3 border"
+                    style={{
+                      backgroundColor: sectionColor?.fill,
+                      borderColor: sectionColor?.stroke,
+                    }}
+                  >
+                    <div className="text-base font-bold truncate text-neu8">
+                      {section.courseSubject} {section.courseNumber}
+                    </div>
+                    <div className="text-base truncate text-neu6">
+                      CRN {section.crn}
+                    </div>
+                    <div className="text-base truncate text-neu6 italic">
+                      Asynchronous
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+        
+        <div className="grid grid-cols-[65px_repeat(7,1fr)]" style={{ minHeight: `${minCalendarHeight}px` }}>
+        {/* Time Column */}
+        <div className="bg-white">
+          <div className="relative h-[calc(100%-3rem)] mt-2">
+            {timeSlots.map((time, index) => {
+              return (
+                <div
+                  key={time}
+                  className="absolute w-full flex items-start justify-end pr-2 text-sm text-neu6"
+                  style={{ top: `${(index / totalHours) * 100}%`, height: `${(1 / totalHours) * 100}%` }}
+                >
+                  <span className="-translate-y-1/2">{time}</span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Day Columns */}
+        {days.map((day, idx) => (
+          <div key={day.index} className="relative bg-white">
+            {/* Time Grid Lines */}
+            <div className="relative h-[calc(100%-3rem)] mt-2">
+              {/* Top border for 12 AM */}
+              <div className="absolute w-full border-t border-gray-200" style={{ top: '0%' }} />
+              
+              {timeSlots.map((_, index) => {
+                const isLastSlot = index === timeSlots.length - 1;
+                return (
+                  <div
+                    key={index}
+                    className={`absolute w-full ${isLastSlot ? 'border-b border-transparent' : 'border-b border-gray-200'}`}
+                    style={{ top: `${(index / totalHours) * 100}%`, height: `${(1 / totalHours) * 100}%` }}
+                  />
+                );
+              })}
+
+              {/* Class Blocks */}
+              {scheduledCourses.map((section, sectionIndex) => {
+                const sectionColor = getSectionColor(section, colorMap);
+                return section.meetingTimes.map((meeting, meetingIndex) => {
+                  if (!meeting.days.includes(day.index)) return null;
+
+                  const position = getClassPosition(meeting.startTime, meeting.endTime);
+
+                  return (
+                    <div
+                      key={`${sectionIndex}-${meetingIndex}`}
+                      className="absolute w-[calc(100%-8px)] mx-1 rounded-md p-2 overflow-hidden border"
+                      style={{
+                        ...position,
+                        backgroundColor: sectionColor?.fill,
+                        borderColor: sectionColor?.stroke,
+                      }}
+                    >
+                      <div className="text-base font-bold truncate text-neu8">
+                        {section.courseSubject} {section.courseNumber}
+                      </div>
+                      <div className="text-base truncate text-neu6">
+                        {section.courseName}
+                      </div>
+                      {section.faculty && (
+                        <div className="text-base truncate text-neu6">
+                          {section.faculty}
+                        </div>
+                      )}
+                      <div className="text-base truncate text-neu6">
+                        CRN {section.crn}
+                      </div>
+                      <div className="text-base mt-1 text-neu6">
+                        {formatTime(meeting.startTime)} - {formatTime(meeting.endTime)}
+                      </div>
+                    </div>
+                  );
+                });
+              })}
+            </div>
+          </div>
+        ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduler/CourseBox.tsx
+++ b/src/components/scheduler/CourseBox.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Lock, Unlock } from "lucide-react";
+import type { SectionWithCourse } from "@/lib/scheduler/filters";
+import { SectionRow } from "./SectionRow";
+import { type CourseColor } from "@/lib/scheduler/courseColors";
+
+interface CourseBoxProps {
+  sections: SectionWithCourse[];
+  color?: CourseColor;
+}
+
+export function CourseBox({ sections, color }: CourseBoxProps) {
+  const [open, setOpen] = useState(false);
+  const [courseLocked, setCourseLocked] = useState(false);
+
+  const courseId = sections[0] ? `${sections[0].courseSubject} ${sections[0].courseNumber}` : "";
+  const courseName = sections[0] ? sections[0].courseName : "";
+
+  return (
+    <div className="mb-3">
+      <div
+        className="rounded-md px-3 py-2 flex items-start justify-between border"
+        style={{ borderColor: `${color?.stroke}`, backgroundColor: `${color?.fill}` }}
+      >
+        <div className="flex items-start gap-3">
+          <button
+            onClick={() => setCourseLocked((c) => !c)}
+            aria-label={courseLocked ? "Unlock course" : "Lock course"}
+            className="p-1 self-start"
+          >
+            {courseLocked ? <Lock className="w-4 h-4 text-red-500" /> : <Unlock className="w-4 h-4 text-gray-400" />}
+          </button>
+          <div className="mt-1 leading-tight">
+            <div className="font-bold text-sm text-neu8 mb-1">{courseId}</div>
+            <div className="text-sm text-neu7">{courseName}</div>
+          </div>
+        </div>
+        <button onClick={() => setOpen((s) => !s)} aria-label={open ? "Collapse" : "Expand"} className="p-1">
+          {open ? <ChevronUp className="w-5 h-5 text-gray-600" /> : <ChevronDown className="w-5 h-5 text-gray-600" />}
+        </button>
+      </div>
+
+      {open && (
+        <div className="rounded-md mt-2 overflow-hidden border" style={{ borderColor: `${color?.fill}` }}>
+          {sections.map((s) => (
+            <SectionRow key={s.crn} section={s} />
+          ))}
+        </div>)}
+    </div>
+  );
+}

--- a/src/components/scheduler/FilterMultiSelect.tsx
+++ b/src/components/scheduler/FilterMultiSelect.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+import { Label } from "@/components/ui/label";
+import {
+  Command,
+  CommandInput,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandEmpty,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { PlusIcon } from 'lucide-react';
+import { cn } from "@/lib/cn";
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface FilterMultiSelectProps {
+  label: string;
+  options: Option[];
+  selected: string[];
+  onSelectedChange: (values: string[]) => void;
+  placeholder?: string;
+}
+
+export function FilterMultiSelect({
+  label,
+  options,
+  selected,
+  onSelectedChange,
+}: FilterMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+
+  const selectedOptions = options.filter((opt) =>
+    selected.includes(opt.value)
+  );
+
+  const clearAll = () => {
+    onSelectedChange([]);
+  };
+
+  const toggleOption = (optionValue: string) => {
+    const option = options.find((opt) => opt.value === optionValue);
+    if (!option) return;
+
+    if (selected.includes(optionValue)) {
+      onSelectedChange(selected.filter((v) => v !== optionValue));
+    } else {
+      onSelectedChange([...selected, optionValue]);
+    }
+  };
+
+  const removeOption = (optionValue: string) => {
+    onSelectedChange(selected.filter((v) => v !== optionValue));
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <Label className="text-muted-foreground text-xs font-bold">
+          {label}
+        </Label>
+        <div className="flex items-center gap-2">
+          {selected.length > 0 && (
+            <button
+              onClick={clearAll}
+              className="text-blue-600 hover:text-blue-600/80 text-xs"
+            >
+              Clear all
+            </button>
+          )}
+
+          <Popover open={open} onOpenChange={setOpen} modal={true}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <PlusIcon
+                  className={cn(
+                    "size-5 transition-transform",
+                    open && "rotate-45"
+                  )}
+                />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-[280px] p-0"
+              align="end"
+            >
+              <Command
+                filter={(value, search, keywords) => {
+                  const v = value.toLowerCase();
+                  const s = search.toLowerCase();
+                  const label = keywords?.join(" ").toLowerCase();
+                  if (v === s) return 1;
+                  if (v.includes(s)) return 0.8;
+                  if (label?.includes(s)) return 0.7;
+                  return 0;
+                }}
+              >
+                <CommandInput
+                  placeholder={`Search ${label.toLowerCase()}...`}
+                  className="text-xs"
+                />
+                <CommandList className="max-h-[300px]">
+                  <CommandEmpty>No results found</CommandEmpty>
+                  <CommandGroup>
+                    {options.map((opt) => (
+                      <CommandItem
+                        key={opt.value}
+                        value={opt.value}
+                        keywords={[opt.label]}
+                        onSelect={toggleOption}
+                        className={cn(
+                          "flex items-center gap-2 py-3 px-4 cursor-pointer",
+                          selected.includes(opt.value) && "font-semibold"
+                        )}
+                      >
+                        {opt.value !== opt.label && (
+                          <div
+                            className={cn("font-bold text-muted-foreground", {
+                              "text-foreground": selected.includes(opt.value),
+                            })}
+                          >
+                            {opt.value}
+                          </div>
+                        )}
+                        <div
+                          className={cn("text-muted-foreground", {
+                            "text-foreground font-semibold": selected.includes(
+                              opt.value
+                            ),
+                          })}
+                        >
+                          {opt.label}
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+      {selectedOptions.length > 0 && (
+        <div className="flex flex-wrap gap-2 pt-3">
+          {selectedOptions.slice(0, 3).map((opt) => (
+            <span
+              key={opt.value}
+              className="inline-flex w-fit items-center rounded-full border bg-secondary px-3 py-1 text-xs"
+            >
+              <span className="flex items-center gap-2">
+                {opt.value !== opt.label && (
+                  <span className="font-bold text-foreground">{opt.value}</span>
+                )}
+                <span
+                  className={cn(
+                    opt.value === opt.label
+                      ? "text-foreground"
+                      : "text-muted-foreground"
+                  )}
+                >
+                  {opt.label}
+                </span>
+              </span>
+              <button
+                onClick={() => removeOption(opt.value)}
+                aria-label={`Remove ${opt.label}`}
+                className="ml-2 rounded-full py-0.5 text-lg leading-none text-muted-foreground hover:text-foreground"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {selectedOptions.length > 3 && (
+            <span className="rounded-full border px-3 py-1 text-xs">
+              +{selectedOptions.length - 3}
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -27,10 +27,21 @@ interface FilterPanelProps {
   nupathOptions: { label: string; value: string }[];
 }
 
-export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions }: FilterPanelProps) {
-  const [courseIdsInput, setCourseIdsInput] = useState("17500, 16048, 15783, 17501");
+export function FilterPanel({
+  filters,
+  onFiltersChange,
+  onGenerateSchedules,
+  isGenerating,
+  nupathOptions,
+}: FilterPanelProps) {
+  const [courseIdsInput, setCourseIdsInput] = useState(
+    "17500, 16048, 15783, 17501",
+  );
 
-  const updateFilter = <K extends keyof ScheduleFilters>(key: K, value: ScheduleFilters[K]) => {
+  const updateFilter = <K extends keyof ScheduleFilters>(
+    key: K,
+    value: ScheduleFilters[K],
+  ) => {
     if (value === undefined || (Array.isArray(value) && value.length === 0)) {
       const { [key]: _, ...rest } = filters;
       onFiltersChange(rest);
@@ -47,7 +58,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
       .split(",")
       .map((id) => parseInt(id.trim()))
       .filter((id) => !isNaN(id));
-    
+
     if (courseIds.length > 0) {
       onGenerateSchedules(courseIds);
     }
@@ -64,12 +75,12 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
           value={courseIdsInput}
           onChange={(e) => setCourseIdsInput(e.target.value)}
           placeholder="Enter course IDs separated by commas (e.g., 17500, 16048)"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2 min-h-[80px] font-mono text-sm"
+          className="mt-2 min-h-[80px] w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
         />
         <Button
           onClick={handleGenerate}
           disabled={isGenerating}
-          className="w-full mt-2"
+          className="mt-2 w-full"
         >
           {isGenerating ? "Generating..." : "Generate Schedules"}
         </Button>
@@ -77,11 +88,11 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       <Separator />
 
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         <h3 className="text-muted-foreground text-xs font-bold">FILTERS</h3>
         <button
           onClick={clearFilters}
-          className="px-3 py-1 text-xs bg-red-100 hover:bg-red-200 text-red-700 rounded"
+          className="rounded bg-red-100 px-3 py-1 text-xs text-red-700 hover:bg-red-200"
         >
           Clear All
         </button>
@@ -94,9 +105,16 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         </Label>
         <input
           type="time"
-          value={filters.startTime ? militaryToTimeString(filters.startTime) : ""}
-          onChange={(e) => updateFilter("startTime", e.target.value ? timeStringToMilitary(e.target.value) : undefined)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
+          value={
+            filters.startTime ? militaryToTimeString(filters.startTime) : ""
+          }
+          onChange={(e) =>
+            updateFilter(
+              "startTime",
+              e.target.value ? timeStringToMilitary(e.target.value) : undefined,
+            )
+          }
+          className="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
         />
       </div>
 
@@ -108,8 +126,13 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         <input
           type="time"
           value={filters.endTime ? militaryToTimeString(filters.endTime) : ""}
-          onChange={(e) => updateFilter("endTime", e.target.value ? timeStringToMilitary(e.target.value) : undefined)}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
+          onChange={(e) =>
+            updateFilter(
+              "endTime",
+              e.target.value ? timeStringToMilitary(e.target.value) : undefined,
+            )
+          }
+          className="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
         />
       </div>
 
@@ -125,15 +148,20 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
           min="0"
           max="7"
           value={filters.minDaysFree ?? ""}
-          onChange={(e) => updateFilter("minDaysFree", e.target.value ? parseInt(e.target.value) : undefined)}
+          onChange={(e) =>
+            updateFilter(
+              "minDaysFree",
+              e.target.value ? parseInt(e.target.value) : undefined,
+            )
+          }
           placeholder="0-7"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
+          className="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
         />
       </div>
 
       {/* Days Free Checkboxes */}
       <div>
-        <Label className="text-muted-foreground text-xs font-bold block mb-2">
+        <Label className="text-muted-foreground mb-2 block text-xs font-bold">
           SPECIFIC DAYS FREE
         </Label>
         <div className="flex flex-wrap gap-2">
@@ -146,7 +174,10 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
             { value: 5, label: "Fri" },
             { value: 6, label: "Sat" },
           ].map((day) => (
-            <label key={day.value} className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
+            <label
+              key={day.value}
+              className="flex cursor-pointer items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 hover:bg-gray-50"
+            >
               <input
                 type="checkbox"
                 checked={filters.specificDaysFree?.includes(day.value) ?? false}
@@ -154,8 +185,11 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
                   const currentDays = filters.specificDaysFree || [];
                   const newDays = e.target.checked
                     ? [...currentDays, day.value]
-                    : currentDays.filter(d => d !== day.value);
-                  updateFilter("specificDaysFree", newDays.length > 0 ? newDays : undefined);
+                    : currentDays.filter((d) => d !== day.value);
+                  updateFilter(
+                    "specificDaysFree",
+                    newDays.length > 0 ? newDays : undefined,
+                  );
                 }}
                 className="rounded"
               />
@@ -176,9 +210,14 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
           type="number"
           min="0"
           value={filters.minSeatsLeft ?? ""}
-          onChange={(e) => updateFilter("minSeatsLeft", e.target.value ? parseInt(e.target.value) : undefined)}
+          onChange={(e) =>
+            updateFilter(
+              "minSeatsLeft",
+              e.target.value ? parseInt(e.target.value) : undefined,
+            )
+          }
           placeholder="Any"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
+          className="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
         />
       </div>
 
@@ -191,9 +230,14 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
           type="number"
           min="0"
           value={filters.minHonorsCourses ?? ""}
-          onChange={(e) => updateFilter("minHonorsCourses", e.target.value ? parseInt(e.target.value) : undefined)}
+          onChange={(e) =>
+            updateFilter(
+              "minHonorsCourses",
+              e.target.value ? parseInt(e.target.value) : undefined,
+            )
+          }
           placeholder="Any"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2"
+          className="mt-2 w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
         />
       </div>
 
@@ -201,12 +245,15 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       {/* NUPath Requirement */}
       <div>
-        <Label className="text-muted-foreground text-xs font-bold block mb-2">
+        <Label className="text-muted-foreground mb-2 block text-xs font-bold">
           NUPATH REQUIREMENTS
         </Label>
         <div className="flex flex-wrap gap-2">
           {nupathOptions.map((nupath) => (
-            <label key={nupath.value} className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-lg cursor-pointer hover:bg-gray-50">
+            <label
+              key={nupath.value}
+              className="flex cursor-pointer items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 hover:bg-gray-50"
+            >
               <input
                 type="checkbox"
                 checked={filters.nupaths?.includes(nupath.value) ?? false}
@@ -214,14 +261,15 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
                   const currentNupaths = filters.nupaths || [];
                   const newNupaths = e.target.checked
                     ? [...currentNupaths, nupath.value]
-                    : currentNupaths.filter(n => n !== nupath.value);
-                  updateFilter("nupaths", newNupaths.length > 0 ? newNupaths: undefined);
+                    : currentNupaths.filter((n) => n !== nupath.value);
+                  updateFilter(
+                    "nupaths",
+                    newNupaths.length > 0 ? newNupaths : undefined,
+                  );
                 }}
                 className="rounded"
               />
-              <span className="text-sm">
-                {nupath.label}
-              </span>
+              <span className="text-sm">{nupath.label}</span>
             </label>
           ))}
         </div>

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -5,6 +5,7 @@ import { type ScheduleFilters } from "@/lib/scheduler/filters";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
+import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
 
 // Convert time string (e.g., "09:00") to military format (e.g., 900)
 function timeStringToMilitary(timeStr: string): number {
@@ -19,24 +20,24 @@ function militaryToTimeString(time: number): string {
   return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
 }
 
-interface FilterPanelProps {
-  filters: ScheduleFilters;
-  onFiltersChange: (filters: ScheduleFilters) => void;
-  onGenerateSchedules: (courseIds: number[]) => void;
-  isGenerating: boolean;
-  nupathOptions: { label: string; value: string }[];
-}
-
 export function FilterPanel({
   filters,
   onFiltersChange,
   onGenerateSchedules,
   isGenerating,
   nupathOptions,
-}: FilterPanelProps) {
-  const [courseIdsInput, setCourseIdsInput] = useState(
-    "17500, 16048, 15783, 17501",
-  );
+  term,
+  termName,
+}: {
+  filters: ScheduleFilters;
+  onFiltersChange: (filters: ScheduleFilters) => void;
+  onGenerateSchedules: (courseIds: number[]) => void;
+  isGenerating: boolean;
+  nupathOptions: { label: string; value: string }[];
+  term: string;
+  termName: string;
+}) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const updateFilter = <K extends keyof ScheduleFilters>(
     key: K,
@@ -52,39 +53,26 @@ export function FilterPanel({
 
   const clearFilters = () => onFiltersChange({});
 
-  const handleGenerate = () => {
-    // Parse course IDs from input
-    const courseIds = courseIdsInput
-      .split(",")
-      .map((id) => parseInt(id.trim()))
-      .filter((id) => !isNaN(id));
-
-    if (courseIds.length > 0) {
-      onGenerateSchedules(courseIds);
-    }
-  };
-
   return (
     <div className="bg-background h-[calc(100vh-72px)] w-full space-y-4 overflow-y-scroll px-4 py-4">
-      {/* Course IDs Input */}
+      {/* Add Courses Button */}
       <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          COURSE IDs
-        </Label>
-        <textarea
-          value={courseIdsInput}
-          onChange={(e) => setCourseIdsInput(e.target.value)}
-          placeholder="Enter course IDs separated by commas (e.g., 17500, 16048)"
-          className="mt-2 min-h-[80px] w-full rounded-lg border border-gray-300 px-3 py-2 font-mono text-sm focus:ring-2 focus:ring-blue-500 focus:outline-none"
-        />
         <Button
-          onClick={handleGenerate}
+          onClick={() => setIsModalOpen(true)}
           disabled={isGenerating}
-          className="mt-2 w-full"
+          className="w-full"
         >
-          {isGenerating ? "Generating..." : "Generate Schedules"}
+          Add Courses
         </Button>
       </div>
+
+      <AddCoursesModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        term={term}
+        termName={termName}
+        onGenerateSchedules={onGenerateSchedules}
+      />
 
       <Separator />
 

--- a/src/components/scheduler/SchedulerView.tsx
+++ b/src/components/scheduler/SchedulerView.tsx
@@ -18,13 +18,15 @@ function formatDays(days: number[]): string {
   return days.map((d) => dayNames[d]).join(", ");
 }
 
-interface SchedulerViewProps {
+export function SchedulerView({
+  schedules,
+  totalSchedules,
+  filters,
+}: {
   schedules: SectionWithCourse[][];
   totalSchedules: number;
   filters: ScheduleFilters;
-}
-
-export function SchedulerView({ schedules, totalSchedules, filters }: SchedulerViewProps) {
+}) {
   return (
     <div className="h-[calc(100vh-72px)] w-full space-y-4 overflow-y-scroll px-6 py-4">
       {/* Active Filters Summary */}

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -6,12 +6,17 @@ import { filterSchedules, type ScheduleFilters, type SectionWithCourse } from "@
 import { SchedulerView } from "./SchedulerView";
 import { FilterPanel } from "./FilterPanel";
 
-interface SchedulerWrapperProps {
+export function SchedulerWrapper({
+  initialSchedules,
+  nupathOptions,
+  term,
+  termName,
+}: {
   initialSchedules: SectionWithCourse[][];
   nupathOptions: { label: string; value: string }[];
-}
-
-export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
+  term: string;
+  termName: string;
+}) {
   const router = useRouter();
   const [filters, setFilters] = useState<ScheduleFilters>({});
   const [isPending, startTransition] = useTransition();
@@ -37,6 +42,8 @@ export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerW
           onGenerateSchedules={handleGenerateSchedules}
           isGenerating={isPending}
           nupathOptions={nupathOptions}
+          term={term}
+          termName={termName}
         />
       </div>
       <div className="col-span-5 pl-6">

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -6,26 +6,30 @@ import { filterSchedules, type ScheduleFilters, type SectionWithCourse } from "@
 import { SchedulerView } from "./SchedulerView";
 import { FilterPanel } from "./FilterPanel";
 
-export function SchedulerWrapper({
-  initialSchedules,
-  nupathOptions,
-  term,
-  termName,
-}: {
+interface SchedulerWrapperProps {
   initialSchedules: SectionWithCourse[][];
   nupathOptions: { label: string; value: string }[];
   term: string;
   termName: string;
-}) {
+}
+
+export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termName }: SchedulerWrapperProps) {
   const router = useRouter();
-  const [filters, setFilters] = useState<ScheduleFilters>({});
+  const [filters, setFilters] = useState<ScheduleFilters>({includesOnline: true, includeHonors: true});
   const [isPending, startTransition] = useTransition();
 
-  const handleGenerateSchedules = async (courseIds: number[]) => {
+  const handleGenerateSchedules = async (lockedCourseIds: number[], optionalCourseIds: number[]) => {
     startTransition(() => {
       // Navigate to the same page with course IDs in the URL
       // This will trigger a server-side re-render with the new schedules
-      router.push(`/scheduler?courseIds=${courseIds.join(",")}`);
+      const params = new URLSearchParams();
+      if (lockedCourseIds.length > 0) {
+        params.set("lockedCourseIds", lockedCourseIds.join(","));
+      }
+      if (optionalCourseIds.length > 0) {
+        params.set("optionalCourseIds", optionalCourseIds.join(","));
+      }
+      router.push(`/scheduler?${params.toString()}`);
     });
   };
 
@@ -42,6 +46,7 @@ export function SchedulerWrapper({
           onGenerateSchedules={handleGenerateSchedules}
           isGenerating={isPending}
           nupathOptions={nupathOptions}
+          filteredSchedules={filteredSchedules}
           term={term}
           termName={termName}
         />
@@ -49,7 +54,6 @@ export function SchedulerWrapper({
       <div className="col-span-5 pl-6">
         <SchedulerView
           schedules={filteredSchedules}
-          totalSchedules={initialSchedules.length}
           filters={filters}
         />
       </div>

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -9,11 +9,9 @@ import { FilterPanel } from "./FilterPanel";
 interface SchedulerWrapperProps {
   initialSchedules: SectionWithCourse[][];
   nupathOptions: { label: string; value: string }[];
-  term: string;
-  termName: string;
 }
 
-export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termName }: SchedulerWrapperProps) {
+export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
   const router = useRouter();
   const [filters, setFilters] = useState<ScheduleFilters>({includesOnline: true, includeHonors: true});
   const [isPending, startTransition] = useTransition();
@@ -47,8 +45,6 @@ export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termNa
           isGenerating={isPending}
           nupathOptions={nupathOptions}
           filteredSchedules={filteredSchedules}
-          term={term}
-          termName={termName}
         />
       </div>
       <div className="col-span-5 pl-6">

--- a/src/components/scheduler/SectionRow.tsx
+++ b/src/components/scheduler/SectionRow.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import { Lock, Unlock } from "lucide-react";
+import type { SectionWithCourse } from "@/lib/scheduler/filters";
+
+interface SectionRowProps {
+  section: SectionWithCourse;
+}
+
+export function SectionRow({ section }: SectionRowProps) {
+  const [locked, setLocked] = useState(false);
+  const seatDelta = section.seatRemaining / section.seatCapacity;
+  return (
+    <div className="flex items-start justify-between px-3 py-3">
+      <div className="flex items-start gap-3">
+        <button
+          onClick={() => setLocked((l) => !l)}
+          aria-label={locked ? "Unlock section" : "Lock section"}
+          className="p-1 self-start"
+        >
+          {locked ? <Lock className="w-4 h-4 text-red-500" /> : <Unlock className="w-4 h-4 text-gray-400" />}
+        </button>
+        <div>
+          <div className="font-bold text-sm text-neu8 my-1">CRN {section.crn}</div>
+          <div className="text-sm text-neu6">{formatFaculty(section.faculty)}</div>
+          <div className="text-sm text-neu6 mb-1">
+            <MeetingTimes meetings={section.meetingTimes} />
+          </div>
+          <span
+            className={cn(
+              "inline-block shrink-0 rounded-full px-2 py-1 text-sm font-medium whitespace-nowrap",
+              seatDelta > 0.2 && "bg-green-100 text-green-700",
+              seatDelta <= 0.2 &&
+                seatDelta > 0.05 &&
+                "bg-yellow-100 text-yellow-700",
+              seatDelta <= 0.05 && "bg-red-100 text-red-700",
+            )}
+          >
+            {section.seatRemaining} / {section.seatCapacity}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MeetingTimes({ meetings }: { meetings: SectionWithCourse["meetingTimes"] }) {
+  const dayLetters = ["S", "M", "Tu", "W", "Th", "F", "S"];
+
+  if (!meetings || meetings.length === 0 || meetings[0].days.length === 0) {
+    return <span>TBA</span>;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {meetings.map((m, i) => {
+        const days = Array.from(new Set(m.days)).sort((a, b) => a - b);
+        const daysStr = days.map((d) => dayLetters[d] ?? "").join("");
+        const timeStr = formatTimeRange(m.startTime, m.endTime);
+        return (
+          <span key={i} className="whitespace-nowrap">
+            {daysStr}: {timeStr}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatTimeRange(startTime: number, endTime: number) {
+  const startHours = Math.floor(startTime / 100);
+  const startMinutes = startTime % 100;
+  const endHours = Math.floor(endTime / 100);
+  const endMinutes = endTime % 100;
+
+  const startIsPM = startHours >= 12;
+  const endIsPM = endHours >= 12;
+
+  const start12Hour = startHours % 12 || 12;
+  const end12Hour = endHours % 12 || 12;
+
+  const formattedStart = `${start12Hour}:${startMinutes.toString().padStart(2, "0")}`;
+  const formattedEnd = `${end12Hour}:${endMinutes.toString().padStart(2, "0")}`;
+
+  return `${formattedStart}${startIsPM ? "pm" : "am"} - ${formattedEnd}${endIsPM ? "pm" : "am"}`;
+}
+
+function formatFaculty(f: string) {
+  const [lastName, firstName] = f.split(",");
+  if (!lastName || !firstName) {
+    return "NA";
+  }
+  return `${firstName.trim()[0]}. ${lastName}`;
+}

--- a/src/components/scheduler/TimeInput.tsx
+++ b/src/components/scheduler/TimeInput.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronDown } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+interface TimeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  startHour?: number;
+  endHour?: number;
+  intervalMinutes?: number;
+}
+
+function generateTimeOptions(
+  startHour: number,
+  endHour: number,
+  intervalMinutes: number
+): { value: string; label: string }[] {
+  const options: { value: string; label: string }[] = [];
+  
+  for (let hour = startHour; hour <= endHour; hour++) {
+    for (let minutes = 0; minutes < 60; minutes += intervalMinutes) {
+      // Skip times after the end hour
+      if (hour === endHour && minutes > 0) break;
+      
+      const timeValue = `${hour.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+      const isPM = hour >= 12;
+      const displayHour = hour > 12 ? hour - 12 : hour === 0 ? 12 : hour;
+      const label = `${displayHour}:${minutes.toString().padStart(2, "0")} ${isPM ? "PM" : "AM"}`;
+      
+      options.push({ value: timeValue, label });
+    }
+  }
+  
+  return options;
+}
+
+export function TimeInput({ 
+  value, 
+  onChange,
+  startHour = 6,
+  endHour = 24,
+  intervalMinutes = 15,
+}: TimeInputProps) {
+  const [open, setOpen] = useState(false);
+  
+  const timeOptions = generateTimeOptions(startHour, endHour, intervalMinutes);
+  
+  const selectedOption = timeOptions.find((option) => option.value === value);
+  const displayValue = selectedOption?.label || "-- : -- --";
+
+  return (      
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button className="flex w-20 items-center gap-2 bg-transparent font-medium text-muted-foreground hover:text-foreground/80 focus:outline-none">
+            <span className="inline-block w-14 text-left text-sm">{displayValue}</span>
+            <ChevronDown className="h-4 w-4 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[200px] p-0" align="end">
+          <Command>
+            <CommandInput placeholder="-- : --" />
+            <CommandList>
+              <CommandEmpty>No time found.</CommandEmpty>
+              <CommandGroup>
+                {timeOptions.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    value={option.label}
+                    onSelect={() => {
+                      onChange(option.value);
+                      setOpen(false);
+                    }}
+                  >
+                    <Check
+                      className={`mr-2 h-4 w-4 ${
+                        option.value === value ? "opacity-100" : "opacity-0"
+                      }`}
+                    />
+                    {option.label}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+  );
+}

--- a/src/lib/controllers/getTerms.ts
+++ b/src/lib/controllers/getTerms.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { db } from "@/db";
 import { termsT } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import type { GroupedTerms } from "../types";
 
 // getTerms retreives all the terms from the db
@@ -36,4 +37,15 @@ export async function getTerms() {
   groupedTerms.law.sort((a, b) => b.term.localeCompare(a.term));
 
   return groupedTerms;
+}
+
+// getTermName retrieves the display name for a specific term
+export async function getTermName(termId: string) {
+  const result = await db
+    .select({ name: termsT.name })
+    .from(termsT)
+    .where(eq(termsT.term, termId))
+    .limit(1);
+
+  return result[0]?.name ?? termId;
 }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -20,6 +20,6 @@ export const schedulerFlag = flag({
   key: "scheduler",
   description: "Enable scheduler page",
   decide() {
-    return true;
+    return false;
   },
 });

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -20,6 +20,6 @@ export const schedulerFlag = flag({
   key: "scheduler",
   description: "Enable scheduler page",
   decide() {
-    return false;
+    return true;
   },
 });

--- a/src/lib/scheduler/courseColors.ts
+++ b/src/lib/scheduler/courseColors.ts
@@ -1,0 +1,57 @@
+import { type SectionWithCourse } from "./filters";
+
+export interface CourseColor {
+  fill: string;
+  stroke: string;
+}
+
+// Course color palette - same as defined in globals.css
+export const COURSE_COLORS: CourseColor[] = [
+  { fill: "var(--scheduler-course-yellow-fill)", stroke: "var(--scheduler-course-yellow-stroke)" },
+  { fill: "var(--scheduler-course-red-fill)", stroke: "var(--scheduler-course-red-stroke)" },
+  { fill: "var(--scheduler-course-blue-fill)", stroke: "var(--scheduler-course-blue-stroke)" },
+  { fill: "var(--scheduler-course-purple-fill)", stroke: "var(--scheduler-course-purple-stroke)" },
+  { fill: "var(--scheduler-course-green-fill)", stroke: "var(--scheduler-course-green-stroke)" },
+  { fill: "var(--scheduler-course-orange-fill)", stroke: "var(--scheduler-course-orange-stroke)" },
+  { fill: "var(--scheduler-course-pink-fill)", stroke: "var(--scheduler-course-pink-stroke)" },
+  { fill: "var(--scheduler-course-gray-fill)", stroke: "var(--scheduler-course-gray-stroke)" },
+  { fill: "var(--scheduler-course-brown-fill)", stroke: "var(--scheduler-course-brown-stroke)" },
+];
+
+// Creates a consistent course key from a section
+export function getCourseKey(section: SectionWithCourse): string {
+  return `${section.courseSubject} ${section.courseNumber}`;
+}
+
+
+// Builds a map of course keys to colors based on filtered schedules.
+// Colors are assigned alphabetically by course key and cycle through the palette.
+export function getCourseColorMap(filteredSchedules: SectionWithCourse[][]): Map<string, CourseColor> {
+  // Collect all unique course keys across all schedules
+  const courseKeySet = new Set<string>();
+  
+  for (const schedule of filteredSchedules) {
+    for (const section of schedule) {
+      courseKeySet.add(getCourseKey(section));
+    }
+  }
+
+  // Sort course keys alphabetically for consistent color assignment
+  const sortedCourseKeys = Array.from(courseKeySet).sort();
+
+  // Assign colors by index, cycling through the palette
+  const colorMap = new Map<string, CourseColor>();
+  sortedCourseKeys.forEach((courseKey, index) => {
+    colorMap.set(courseKey, COURSE_COLORS[index % COURSE_COLORS.length]);
+  });
+
+  return colorMap;
+}
+
+// Gets the color for a specific section based on its course
+export function getSectionColor(
+  section: SectionWithCourse,
+  colorMap: Map<string, CourseColor>
+): CourseColor | undefined {
+  return colorMap.get(getCourseKey(section));
+}

--- a/src/lib/scheduler/filters.ts
+++ b/src/lib/scheduler/filters.ts
@@ -13,8 +13,9 @@ export type ScheduleFilters = {
   specificDaysFree?: number[]; // array of day numbers (0=Sunday, 1=Monday, 2=Tuesday, ..., 6=Saturday)
   minDaysFree?: number;
   minSeatsLeft?: number;
-  minHonorsCourses?: number;
+  includeHonors?: boolean;
   nupaths?: string[];
+  includesOnline?: boolean;
 };
 
 // Helper function to check if a section conflicts with time constraints
@@ -81,6 +82,13 @@ export const sectionPassesFilters = (
     return false;
   }
 
+  // The only time we care is if we want to exclude online courses
+  if (filters.includesOnline == false) {
+    if (section.campus == "Online") {
+      return false;
+    }
+  }
+
   return true;
 };
 
@@ -137,10 +145,10 @@ export const schedulePassesFilters = (
     }
   }
 
-  // Check minimum honors courses (only if provided)
-  if (filters.minHonorsCourses !== undefined) {
+  // Check that no honors courses are included (only if specified)
+  if (filters.includeHonors == false) {
     const honorsCount = schedule.filter((section) => section.honors).length;
-    if (honorsCount < filters.minHonorsCourses) {
+    if (honorsCount > 0) {
       return false;
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { Requisite } from "@/scraper/reqs";
+
 export interface Term {
   term: string;
   name: string;
@@ -12,4 +14,24 @@ export interface GroupedTerms {
 export interface Subject {
   label: string;
   value: string;
+}
+
+export interface CourseSearchResult {
+  id: number;
+  name: string;
+  courseNumber: string;
+  subject: string;
+  maxCredits: string;
+  minCredits: string;
+  nupaths: string[];
+  nupathNames: string[];
+  prereqs: Requisite;
+  coreqs: Requisite;
+  postreqs: Requisite;
+  totalSections: number;
+  sectionsWithSeats: number;
+  campus: string[];
+  classType: string[];
+  honors: boolean;
+  score: number;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
Summary
     - Implements the Add Courses modal on the catalog page with full course selection functionality.
     
Changes
     - New `AddCoursesModal` component with two-column layout
     - Real-time course search via `/api/search` endpoint
     - Course selection (add/remove, max 10 courses)
     - Lock/unlock toggle for selected courses
     - Generate schedules button (navigates to scheduler page)
     - Term display name conversion (shows "Spring 2026" instead of "202630")
     - Loading states and error handling
     - Backend API integration with debounced search
     
Testing
     - [x] Modal opens from catalog page
     - [x] Course search works with real API data
     - [x] Add/remove courses functionality
     - [x] Lock/unlock toggle works
     - [x] Generate schedules navigates correctly
     - [x] Term display name shows correctly
     
Future Work (not in this PR)
     - Campus filtering (placeholder implemented)
     - Child sections (recitations/labs)
     - Info button functionality

![0FCC8BE5-4157-4198-84D9-8260A10C710B](https://github.com/user-attachments/assets/ca378109-6708-469d-b6f9-1a2155dadd81)