### PR TITLE
feat: Add course selection modal to catalog page

### DIFF
--- a/src/app/(app)/catalog/[term]/page.tsx
+++ b/src/app/(app)/catalog/[term]/page.tsx
@@ -1,12 +1,14 @@
 import { Searchskie } from "@/components/icons/Searchskie";
 
-export default function Page() {
+export default async function Page() {
   return (
     <div className="bg-neu1 grid h-full min-h-0 w-full place-content-center overflow-y-scroll rounded-lg rounded-b-none border border-b-0">
-      <div className="flex flex-col items-center gap-1 text-center">
+      <div className="flex flex-col items-center gap-2 text-center">
         <Searchskie className="w-72 pb-8" />
         <h1 className="text-xl font-semibold">Looking for something?</h1>
-        <p className="">Select a course to see more of its information</p>
+        <p className="text-muted-foreground text-sm">
+          Search for a course or use the scheduler to plan your semester
+        </p>
       </div>
     </div>
   );

--- a/src/app/(app)/scheduler/page.tsx
+++ b/src/app/(app)/scheduler/page.tsx
@@ -1,7 +1,9 @@
 import { db } from "@/db";
-import { nupathsT } from "@/db/schema";
+import { nupathsT, coursesT } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import { generateSchedules } from "@/lib/scheduler/generateSchedules";
 import { SchedulerWrapper } from "@/components/scheduler/SchedulerWrapper";
+import { getTermName } from "@/lib/controllers/getTerms";
 
 export default async function Page({
   searchParams,
@@ -26,6 +28,32 @@ export default async function Page({
     ? await generateSchedules(lockedCourseIds, optionalCourseIds) 
     : [];
 
+  const allCourseIds = [...lockedCourseIds, ...optionalCourseIds];
+
+  // Get term from first course to show term name, or use default
+  let term = "202630";
+  let termName = "Spring 2026";
+  
+  if (allCourseIds.length > 0) {
+    const firstCourse = await db
+      .select({ term: coursesT.term })
+      .from(coursesT)
+      .where(eq(coursesT.id, allCourseIds[0]))
+      .limit(1);
+    
+    term = firstCourse[0]?.term || "202630";
+    termName = await getTermName(term);
+  } else {
+    // Get the current term - fetch from the first course or use a default
+    const firstCourse = await db
+      .select({ term: coursesT.term })
+      .from(coursesT)
+      .limit(1);
+    
+    term = firstCourse[0]?.term || "202630";
+    termName = await getTermName(term);
+  }
+
   // Fetch available NUPath options
   const nupathOptions = await db
     .selectDistinct({ short: nupathsT.short, name: nupathsT.name})
@@ -34,7 +62,12 @@ export default async function Page({
 
   return (
     <div className="bg-secondary h-full w-full px-4 pt-4 xl:px-6">
-      <SchedulerWrapper initialSchedules={allSchedules} nupathOptions={nupathOptions} />
+      <SchedulerWrapper 
+        initialSchedules={allSchedules} 
+        nupathOptions={nupathOptions}
+        term={term}
+        termName={termName}
+      />
     </div>
   );
 }

--- a/src/components/catalog/AddCoursesWithModal.tsx
+++ b/src/components/catalog/AddCoursesWithModal.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
+
+export function AddCoursesWithModal({
+  term,
+  termName,
+}: {
+  term: string;
+  termName: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)} className="mt-4">
+        Add Courses
+      </Button>
+
+      <AddCoursesModal
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        term={term}
+        termName={termName}
+      />
+    </>
+  );
+}
+

--- a/src/components/navigation/NavBar.tsx
+++ b/src/components/navigation/NavBar.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Bookmark, CircleQuestionMark, DoorOpen } from "lucide-react";
+import { Bookmark, CircleQuestionMark, DoorOpen, Calendar } from "lucide-react";
 import { use } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -47,9 +47,10 @@ export function NavBar({
         <Link
           href="/scheduler"
           data-active={pathname === "/scheduler"}
-          className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center rounded-full border-1 p-2 text-sm"
+          className="bg-neu1 data-[active=true]:border-neu3 flex w-full items-center gap-2 rounded-full border-1 px-4 py-2 text-sm"
         >
-          Scheduler
+          <Calendar className="size-4" />
+          <span>Scheduler</span>
         </Link>
       )}
       {faqFlag && (

--- a/src/components/scheduler/AddCourseModal.tsx
+++ b/src/components/scheduler/AddCourseModal.tsx
@@ -55,32 +55,19 @@ export function AddCoursesModal({
   term = "Spring 2026",
   termName = "Spring 2026",
   onGenerateSchedules,
-  initialSelectedCourses,
-  onSelectedCoursesChange,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   term?: string;
   termName?: string;
   onGenerateSchedules?: (lockedCourseIds: number[], optionalCourseIds: number[]) => void;
-  initialSelectedCourses?: SelectedCourse[];
-  onSelectedCoursesChange?: (courses: SelectedCourse[]) => void;
 }) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCourses, setSelectedCoursesInternal] = useState<SelectedCourse[]>(initialSelectedCourses || []);
+  const [selectedCourses, setSelectedCourses] = useState<SelectedCourse[]>([]);
   const [campus, setCampus] = useState("Boston Campus");
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const isStale = deferredSearchQuery !== searchQuery;
-
-  // Sync internal state with external state
-  const setSelectedCourses = (courses: SelectedCourse[] | ((prev: SelectedCourse[]) => SelectedCourse[])) => {
-    setSelectedCoursesInternal((prev) => {
-      const newCourses = typeof courses === "function" ? courses(prev) : courses;
-      onSelectedCoursesChange?.(newCourses);
-      return newCourses;
-    });
-  };
 
   const handleCourseSelect = (course: Course) => {
     if (isSelected(course.code)) {
@@ -146,8 +133,7 @@ export function AddCoursesModal({
       router.push(`/scheduler?${params.toString()}`);
     }
 
-    // Keep modal open so users can adjust their selection
-    // onOpenChange(false);
+    onOpenChange(false);
   };
 
   const isSelected = (courseCode: string): boolean => {

--- a/src/components/scheduler/AddCourseModal.tsx
+++ b/src/components/scheduler/AddCourseModal.tsx
@@ -1,0 +1,472 @@
+"use client";
+
+import { useState, useDeferredValue, Suspense, use, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  X,
+  Search,
+  Lock,
+  LockOpen,
+  Info,
+  Trash2,
+  ChevronDown,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/cn";
+import type { CourseSearchResult } from "@/lib/types";
+
+interface Course {
+  id: number;
+  code: string;
+  name: string;
+}
+
+interface SelectedCourse {
+  id?: number;
+  code: string;
+  name: string;
+  children: Course[];
+  isLocked?: boolean;
+}
+
+// this acts as a single value cache for the data fetcher - the fetch promise has to be stored outside
+// the react tree since otherwise they would be recreated on every rerender
+let cacheKey = "!";
+let cachePromise: Promise<unknown> = new Promise((r) => r([]));
+
+function fetcher<T>(key: string, p: () => string) {
+  if (!Object.is(cacheKey, key)) {
+    cacheKey = key;
+    // if window is undefined, then we are ssr and thus cannot do a relative fetch
+    if (typeof window !== "undefined") {
+      // PERF: next caching on the fetch
+      cachePromise = fetch(p()).then((r) => r.json());
+    }
+  }
+
+  return cachePromise as Promise<T>;
+}
+
+export function AddCoursesModal({
+  open,
+  onOpenChange,
+  term = "Spring 2026",
+  termName = "Spring 2026",
+  onGenerateSchedules,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  term?: string;
+  termName?: string;
+  onGenerateSchedules?: (courseIds: number[]) => void;
+}) {
+  const router = useRouter();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCourses, setSelectedCourses] = useState<SelectedCourse[]>([]);
+  const [campus, setCampus] = useState("Boston Campus");
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const isStale = deferredSearchQuery !== searchQuery;
+
+  const handleCourseSelect = (course: Course) => {
+    if (isSelected(course.code)) {
+      setSelectedCourses((prev) => prev.filter((c) => c.code !== course.code));
+    } else if (selectedCourses.length < 10) {
+      setSelectedCourses((prev) => [
+        ...prev,
+        {
+          id: course.id,
+          code: course.code,
+          name: course.name,
+          children: [],
+          isLocked: false,
+        },
+      ]);
+    }
+  };
+
+  const handleToggleLock = (courseCode: string) => {
+    setSelectedCourses((prev) =>
+      prev.map((course) =>
+        course.code === courseCode
+          ? { ...course, isLocked: !course.isLocked }
+          : course,
+      ),
+    );
+  };
+
+  const handleRemove = (courseCode: string) => {
+    setSelectedCourses((prev) => prev.filter((c) => c.code !== courseCode));
+  };
+
+  const handleGenerateSchedules = () => {
+    const courseIds = selectedCourses
+      .map((course) => course.id)
+      .filter((id): id is number => id !== undefined);
+
+    if (courseIds.length === 0) {
+      console.warn(
+        "No course IDs available. Selected courses:",
+        selectedCourses,
+      );
+      alert("Unable to generate schedules: course IDs are missing.");
+      return;
+    }
+
+    if (onGenerateSchedules) {
+      onGenerateSchedules(courseIds);
+    } else {
+      router.push(`/scheduler?courseIds=${courseIds.join(",")}`);
+    }
+
+    onOpenChange(false);
+  };
+
+  const isSelected = (courseCode: string): boolean => {
+    return selectedCourses.some((course) => course.code === courseCode);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-background relative w-full max-w-3xl rounded-xl shadow-2xl">
+        {/* Header */}
+        <div className="flex items-start justify-between p-6 pb-2">
+          <div className="flex-1 text-center">
+            <h2 className="text-foreground text-2xl font-semibold">
+              Add Courses
+            </h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Add up to 10 courses that you are considering for{" "}
+              <span className="text-foreground font-medium">{termName}</span>.
+            </p>
+          </div>
+          <button
+            onClick={() => onOpenChange(false)}
+            className="text-muted-foreground hover:bg-muted hover:text-foreground absolute top-4 right-4 rounded-sm p-1 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="grid grid-cols-2 gap-4 p-6 pt-4">
+          {/* Left Column - Search */}
+          <div className="flex flex-col gap-3">
+            {/* Campus Dropdown */}
+            <button className="border-border bg-background hover:bg-muted/50 flex items-center justify-between rounded-lg border px-4 py-2.5 text-left transition-colors">
+              <span className="text-primary text-sm font-medium">{campus}</span>
+              <ChevronDown className="text-primary h-4 w-4" />
+            </button>
+
+            {/* Search Input */}
+            <div className="relative">
+              <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+              <Input
+                type="text"
+                placeholder="Search by course number or course name"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+
+            {/* Course List - Added click handler and selection styling */}
+            <div
+              className={cn(
+                "border-border rounded-lg border transition-opacity",
+                isStale && "opacity-60",
+              )}
+            >
+              <Suspense fallback={<CourseListSkeleton />}>
+                <CourseList
+                  searchQuery={deferredSearchQuery}
+                  term={term || ""}
+                  campus={campus}
+                  selectedCourses={selectedCourses}
+                  onCourseSelect={handleCourseSelect}
+                  isSelected={isSelected}
+                />
+              </Suspense>
+            </div>
+          </div>
+
+          {/* Right Column - Selected Courses - Now uses state instead of static data */}
+          <div className="flex flex-col gap-3">
+            <div className="border-border max-h-96 overflow-y-auto rounded-lg border bg-muted/20 p-2">
+              {selectedCourses.length === 0 ? (
+                <div className="text-muted-foreground flex h-full items-center justify-center py-12 text-sm">
+                  No courses selected
+                </div>
+              ) : (
+                selectedCourses.map((course, index) => (
+                  <div
+                    key={course.code + index}
+                    className="group mb-2 flex flex-col rounded-lg border bg-white p-3 shadow-sm transition-all hover:shadow-md"
+                  >
+                    {/* Parent Course */}
+                    <div className="flex items-start gap-2">
+                      <button
+                        onClick={() => handleToggleLock(course.code)}
+                        className="text-muted-foreground hover:text-foreground mt-0.5 shrink-0 transition-colors"
+                        title={course.isLocked ? "Unlock course" : "Lock course"}
+                      >
+                        {course.isLocked ? (
+                          <Lock className="h-4 w-4" />
+                        ) : (
+                          <LockOpen className="h-4 w-4" />
+                        )}
+                      </button>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-2">
+                          <span className="text-foreground text-sm font-bold">
+                            {course.code}
+                          </span>
+                          {course.isLocked && (
+                            <span className="text-muted-foreground text-xs">
+                              Locked
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-muted-foreground mt-0.5 text-left text-sm leading-tight">
+                          {course.name}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                        <button
+                          className="text-muted-foreground hover:bg-muted hover:text-foreground rounded p-1.5 transition-colors"
+                          title="Course info"
+                        >
+                          <Info className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={() => handleRemove(course.code)}
+                          className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive rounded p-1.5 transition-colors"
+                          title="Remove course"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Child Courses (Recitations/Labs) */}
+                    {course.children.length > 0 && (
+                      <div className="mt-2 space-y-1 border-t pt-2">
+                        {course.children.map((child) => (
+                          <div
+                            key={child.code}
+                            className="bg-muted/30 flex items-center gap-2 rounded px-2 py-1.5"
+                          >
+                            <span className="text-foreground text-xs font-medium">
+                              {child.code}
+                            </span>
+                            <span className="text-muted-foreground truncate text-xs">
+                              {child.name}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+
+            {/* Generate Schedules Button */}
+            <Button
+              className="w-full"
+              onClick={handleGenerateSchedules}
+              disabled={selectedCourses.length === 0}
+            >
+              Generate Schedules
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CourseList({
+  searchQuery,
+  term,
+  campus,
+  selectedCourses,
+  onCourseSelect,
+  isSelected,
+}: {
+  searchQuery: string;
+  term: string;
+  campus: string;
+  selectedCourses: SelectedCourse[];
+  onCourseSelect: (course: Course) => void;
+  isSelected: (courseCode: string) => boolean;
+}) {
+  // Handle empty states before using hooks
+  if (!searchQuery) {
+    return (
+      <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+        Start typing to search for courses
+      </div>
+    );
+  }
+
+  if (searchQuery.length > 0 && searchQuery.length < 4) {
+    return (
+      <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+        Type at least 4 characters to search
+      </div>
+    );
+  }
+
+  return (
+    <CourseListContent
+      searchQuery={searchQuery}
+      term={term}
+      campus={campus}
+      selectedCourses={selectedCourses}
+      onCourseSelect={onCourseSelect}
+      isSelected={isSelected}
+    />
+  );
+}
+
+function CourseListContent({
+  searchQuery,
+  term,
+  campus,
+  selectedCourses,
+  onCourseSelect,
+  isSelected,
+}: {
+  searchQuery: string;
+  term: string;
+  campus: string;
+  selectedCourses: SelectedCourse[];
+  onCourseSelect: (course: Course) => void;
+  isSelected: (courseCode: string) => boolean;
+}) {
+  const results = use(
+    fetcher<CourseSearchResult[] | { error: string }>(
+      searchQuery + term + campus,
+      () => {
+        const params = new URLSearchParams();
+        params.set("term", term);
+        params.set("q", searchQuery);
+        // TODO: Add campus filter when campus filtering is implemented
+        // if (campus && campus !== "Boston Campus") {
+        //   params.append("camp", campus);
+        // }
+        return `/api/search?${params.toString()}`;
+      },
+    ),
+  );
+
+  if (!Array.isArray(results)) {
+    if (results.error === "insufficient query length") {
+      return (
+        <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+          Type at least 4 characters to search
+        </div>
+      );
+    }
+
+    return (
+      <div className="text-muted-foreground flex h-72 flex-col items-center justify-center text-sm">
+        <p className="text-destructive">Error: {results.error}</p>
+      </div>
+    );
+  }
+
+  // Transform API response to Course format
+  const courses: Course[] = results.map((result) => ({
+    id: result.id,
+    code: `${result.subject} ${result.courseNumber}`,
+    name: result.name,
+  }));
+
+  if (courses.length === 0) {
+    return (
+      <div className="text-muted-foreground flex h-72 items-center justify-center text-sm">
+        No courses found
+      </div>
+    );
+  }
+
+  const parentRef = useRef(null);
+
+  const virtual = useVirtualizer({
+    count: courses.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 60, // Approximate height of each course item
+    scrollPaddingStart: 8,
+    overscan: 5,
+  });
+
+  const items = virtual.getVirtualItems();
+
+  return (
+    <div ref={parentRef} className="h-72 w-full overflow-y-auto p-2">
+      <div className="relative" style={{ height: virtual.getTotalSize() }}>
+        <div
+          className="absolute top-0 left-0 w-full"
+          style={{
+            transform: `translateY(${items[0]?.start ?? 0}px)`,
+          }}
+        >
+          {items.map((virtualItem) => {
+            const course = courses[virtualItem.index];
+            const selected = isSelected(course.code);
+            return (
+              <button
+                key={virtualItem.key}
+                data-index={virtualItem.index}
+                ref={virtual.measureElement}
+                onClick={() => onCourseSelect(course)}
+                className={cn(
+                  "mb-2 flex w-full flex-col rounded-lg border bg-white p-3 text-left shadow-sm transition-all",
+                  "hover:shadow-md hover:border-primary/50",
+                  selected
+                    ? "border-primary bg-primary/5 ring-2 ring-primary/20"
+                    : "border-border",
+                )}
+              >
+                <div className="flex items-baseline gap-2">
+                  <span className="text-foreground text-sm font-bold">
+                    {course.code}
+                  </span>
+                  {selected && (
+                    <span className="text-primary text-xs font-medium">
+                      Selected
+                    </span>
+                  )}
+                </div>
+                <span className="text-muted-foreground mt-0.5 text-sm">
+                  {course.name}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CourseListSkeleton() {
+  return (
+    <div className="h-72 space-y-2 overflow-y-clip p-2">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="h-14 w-full animate-pulse rounded-lg border bg-white p-3"
+        >
+          <div className="bg-muted mb-1.5 h-4 w-24 rounded"></div>
+          <div className="bg-muted h-3 w-full rounded"></div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/scheduler/AddCourseModal.tsx
+++ b/src/components/scheduler/AddCourseModal.tsx
@@ -55,19 +55,32 @@ export function AddCoursesModal({
   term = "Spring 2026",
   termName = "Spring 2026",
   onGenerateSchedules,
+  initialSelectedCourses,
+  onSelectedCoursesChange,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   term?: string;
   termName?: string;
   onGenerateSchedules?: (lockedCourseIds: number[], optionalCourseIds: number[]) => void;
+  initialSelectedCourses?: SelectedCourse[];
+  onSelectedCoursesChange?: (courses: SelectedCourse[]) => void;
 }) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCourses, setSelectedCourses] = useState<SelectedCourse[]>([]);
+  const [selectedCourses, setSelectedCoursesInternal] = useState<SelectedCourse[]>(initialSelectedCourses || []);
   const [campus, setCampus] = useState("Boston Campus");
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const isStale = deferredSearchQuery !== searchQuery;
+
+  // Sync internal state with external state
+  const setSelectedCourses = (courses: SelectedCourse[] | ((prev: SelectedCourse[]) => SelectedCourse[])) => {
+    setSelectedCoursesInternal((prev) => {
+      const newCourses = typeof courses === "function" ? courses(prev) : courses;
+      onSelectedCoursesChange?.(newCourses);
+      return newCourses;
+    });
+  };
 
   const handleCourseSelect = (course: Course) => {
     if (isSelected(course.code)) {
@@ -133,7 +146,8 @@ export function AddCoursesModal({
       router.push(`/scheduler?${params.toString()}`);
     }
 
-    onOpenChange(false);
+    // Keep modal open so users can adjust their selection
+    // onOpenChange(false);
   };
 
   const isSelected = (courseCode: string): boolean => {

--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -42,8 +42,8 @@ export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarVie
   const minCalendarHeight = totalHours * HOUR_HEIGHT;
 
   // Separate async/remote courses from scheduled courses
-  const asyncCourses = schedule.filter(section => section.campus === "Online");
-  const scheduledCourses = schedule.filter(section => section.campus !== "Online");
+  const asyncCourses = schedule.filter(section => section.meetingTimes.length === 0);
+  const scheduledCourses = schedule.filter(section => section.meetingTimes.length > 0);
 
   // Auto-scroll to 7 AM on mount or when schedule changes
   useEffect(() => {

--- a/src/components/scheduler/CalendarView.tsx
+++ b/src/components/scheduler/CalendarView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { type SectionWithCourse } from "@/lib/scheduler/filters";
 import { type CourseColor, getSectionColor } from "@/lib/scheduler/courseColors";
+import { SectionDetailPopover } from "./SectionDetailPopover";
 
 interface CalendarViewProps {
   schedule: SectionWithCourse[];
@@ -31,28 +32,19 @@ function timeToMinutes(time: number): number {
 
 export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarViewProps) {
   const calendarRef = useRef<HTMLDivElement>(null);
-  
+
   // Define time range (6 AM to midnight)
   const startHour = 6;
   const endHour = 24;
   const totalHours = endHour - startHour;
-  
+
   // Calculate minimum height based on hour height
   const minCalendarHeight = totalHours * HOUR_HEIGHT;
-  
+
   // Separate async/remote courses from scheduled courses
-  const asyncCourses = schedule.filter(section => 
-    !section.meetingTimes || 
-    section.meetingTimes.length === 0 || 
-    section.meetingTimes.every(mt => !mt.days || mt.days.length === 0)
-  );
-  
-  const scheduledCourses = schedule.filter(section => 
-    section.meetingTimes && 
-    section.meetingTimes.length > 0 && 
-    section.meetingTimes.some(mt => mt.days && mt.days.length > 0)
-  );
-  
+  const asyncCourses = schedule.filter(section => section.campus === "Online");
+  const scheduledCourses = schedule.filter(section => section.campus !== "Online");
+
   // Auto-scroll to 7 AM on mount or when schedule changes
   useEffect(() => {
     if (calendarRef.current) {
@@ -61,7 +53,7 @@ export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarVie
       calendarRef.current.scrollTop = scrollPosition;
     }
   }, [scheduleNumber, asyncCourses.length]);
-  
+
   // Define days
   const days = [
     { short: "SUN", full: "SUNDAY", index: 0 },
@@ -95,7 +87,7 @@ export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarVie
   };
 
   return (
-    <div 
+    <div
       ref={calendarRef}
       className="h-full w-full rounded-lg border border-gray-300 bg-white overflow-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]"
     >
@@ -111,7 +103,7 @@ export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarVie
               </div>
             )}
           </div>
-          
+
           {/* Day Headers */}
           {days.map((day) => (
             <div key={day.index} className="h-12 flex items-center justify-center pb-1 bg-white">
@@ -130,81 +122,10 @@ export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarVie
               {asyncCourses.map((section, index) => {
                 const sectionColor = getSectionColor(section, colorMap);
                 return (
-                  <div
-                    key={index}
-                    className="rounded-md p-2 px-3 flex items-center gap-3 border"
-                    style={{
-                      backgroundColor: sectionColor?.fill,
-                      borderColor: sectionColor?.stroke,
-                    }}
-                  >
-                    <div className="text-base font-bold truncate text-neu8">
-                      {section.courseSubject} {section.courseNumber}
-                    </div>
-                    <div className="text-base truncate text-neu6">
-                      CRN {section.crn}
-                    </div>
-                    <div className="text-base truncate text-neu6 italic">
-                      Asynchronous
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-        
-        <div className="grid grid-cols-[65px_repeat(7,1fr)]" style={{ minHeight: `${minCalendarHeight}px` }}>
-        {/* Time Column */}
-        <div className="bg-white">
-          <div className="relative h-[calc(100%-3rem)] mt-2">
-            {timeSlots.map((time, index) => {
-              return (
-                <div
-                  key={time}
-                  className="absolute w-full flex items-start justify-end pr-2 text-sm text-neu6"
-                  style={{ top: `${(index / totalHours) * 100}%`, height: `${(1 / totalHours) * 100}%` }}
-                >
-                  <span className="-translate-y-1/2">{time}</span>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Day Columns */}
-        {days.map((day, idx) => (
-          <div key={day.index} className="relative bg-white">
-            {/* Time Grid Lines */}
-            <div className="relative h-[calc(100%-3rem)] mt-2">
-              {/* Top border for 12 AM */}
-              <div className="absolute w-full border-t border-gray-200" style={{ top: '0%' }} />
-              
-              {timeSlots.map((_, index) => {
-                const isLastSlot = index === timeSlots.length - 1;
-                return (
-                  <div
-                    key={index}
-                    className={`absolute w-full ${isLastSlot ? 'border-b border-transparent' : 'border-b border-gray-200'}`}
-                    style={{ top: `${(index / totalHours) * 100}%`, height: `${(1 / totalHours) * 100}%` }}
-                  />
-                );
-              })}
-
-              {/* Class Blocks */}
-              {scheduledCourses.map((section, sectionIndex) => {
-                const sectionColor = getSectionColor(section, colorMap);
-                return section.meetingTimes.map((meeting, meetingIndex) => {
-                  if (!meeting.days.includes(day.index)) return null;
-
-                  const position = getClassPosition(meeting.startTime, meeting.endTime);
-
-                  return (
+                  <SectionDetailPopover key={index} section={section}>
                     <div
-                      key={`${sectionIndex}-${meetingIndex}`}
-                      className="absolute w-[calc(100%-8px)] mx-1 rounded-md p-2 overflow-hidden border"
+                      className="rounded-md p-2 px-3 flex items-center gap-3 border cursor-pointer hover:opacity-90 transition-opacity"
                       style={{
-                        ...position,
                         backgroundColor: sectionColor?.fill,
                         borderColor: sectionColor?.stroke,
                       }}
@@ -212,29 +133,91 @@ export function CalendarView({ schedule, scheduleNumber, colorMap }: CalendarVie
                       <div className="text-base font-bold truncate text-neu8">
                         {section.courseSubject} {section.courseNumber}
                       </div>
-                      <div className="text-base truncate text-neu6">
-                        {section.courseName}
-                      </div>
-                      {section.faculty && (
-                        <div className="text-base truncate text-neu6">
-                          {section.faculty}
-                        </div>
-                      )}
-                      <div className="text-base truncate text-neu6">
-                        CRN {section.crn}
-                      </div>
-                      <div className="text-base mt-1 text-neu6">
-                        {formatTime(meeting.startTime)} - {formatTime(meeting.endTime)}
-                      </div>
+                      <div className="text-base truncate text-neu6">CRN {section.crn}</div>
+                      <div className="text-base truncate text-neu6 italic">Asynchronous</div>
                     </div>
-                  );
-                });
+                  </SectionDetailPopover>
+                );
               })}
             </div>
           </div>
-        ))}
+        )}
+
+        <div className="grid grid-cols-[65px_repeat(7,1fr)]" style={{ minHeight: `${minCalendarHeight}px` }}>
+          {/* Time Column */}
+          <div className="bg-white">
+            <div className="relative h-[calc(100%-3rem)] mt-2">
+              {timeSlots.map((time, index) => {
+                return (
+                  <div
+                    key={time}
+                    className="absolute w-full flex items-start justify-end pr-2 text-sm text-neu6"
+                    style={{ top: `${(index / totalHours) * 100}%`, height: `${(1 / totalHours) * 100}%` }}
+                  >
+                    <span className="-translate-y-1/2">{time}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Day Columns */}
+          {days.map((day, _idx) => (
+            <div key={day.index} className="relative bg-white">
+              {/* Time Grid Lines */}
+              <div className="relative h-[calc(100%-3rem)] mt-2">
+                {/* Top border for 12 AM */}
+                <div className="absolute w-full border-t border-gray-200" style={{ top: '0%' }} />
+
+                {timeSlots.map((_, index) => {
+                  const isLastSlot = index === timeSlots.length - 1;
+                  return (
+                    <div
+                      key={index}
+                      className={`absolute w-full ${isLastSlot ? 'border-b border-transparent' : 'border-b border-gray-200'}`}
+                      style={{ top: `${(index / totalHours) * 100}%`, height: `${(1 / totalHours) * 100}%` }}
+                    />
+                  );
+                })}
+
+                {/* Class Blocks */}
+                {scheduledCourses.map((section, sectionIndex) => {
+                  const sectionColor = getSectionColor(section, colorMap);
+                  return section.meetingTimes.map((meeting, meetingIndex) => {
+                    if (!meeting.days.includes(day.index)) return null;
+
+                    const position = getClassPosition(meeting.startTime, meeting.endTime);
+
+                    return (
+                      <SectionDetailPopover key={`${sectionIndex}-${meetingIndex}`} section={section}>
+                        <div
+                          className="absolute w-[calc(100%-8px)] mx-1 rounded-md p-2 overflow-hidden border cursor-pointer hover:opacity-90 transition-opacity"
+                          style={{
+                            ...position,
+                            backgroundColor: sectionColor?.fill,
+                            borderColor: sectionColor?.stroke,
+                          }}
+                        >
+                          <div className="text-base font-bold truncate text-neu8">
+                            {section.courseSubject} {section.courseNumber}
+                          </div>
+                          <div className="text-base truncate text-neu6">{section.courseName}</div>
+                          {section.faculty && <div className="text-base truncate text-neu6">{section.faculty}</div>}
+                          <div className="text-base truncate text-neu6">CRN {section.crn}</div>
+                          <div className="text-base mt-1 text-neu6">
+                            {formatTime(meeting.startTime)} - {formatTime(meeting.endTime)}
+                          </div>
+                        </div>
+                      </SectionDetailPopover>
+                    );
+                  });
+                })}
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>
   );
 }
+

--- a/src/components/scheduler/CourseBox.tsx
+++ b/src/components/scheduler/CourseBox.tsx
@@ -9,11 +9,11 @@ import { type CourseColor } from "@/lib/scheduler/courseColors";
 interface CourseBoxProps {
   sections: SectionWithCourse[];
   color?: CourseColor;
+  isLocked?: boolean;
 }
 
-export function CourseBox({ sections, color }: CourseBoxProps) {
+export function CourseBox({ sections, color, isLocked = false }: CourseBoxProps) {
   const [open, setOpen] = useState(false);
-  const [courseLocked, setCourseLocked] = useState(false);
 
   const courseId = sections[0] ? `${sections[0].courseSubject} ${sections[0].courseNumber}` : "";
   const courseName = sections[0] ? sections[0].courseName : "";
@@ -25,13 +25,9 @@ export function CourseBox({ sections, color }: CourseBoxProps) {
         style={{ borderColor: `${color?.stroke}`, backgroundColor: `${color?.fill}` }}
       >
         <div className="flex items-start gap-3">
-          <button
-            onClick={() => setCourseLocked((c) => !c)}
-            aria-label={courseLocked ? "Unlock course" : "Lock course"}
-            className="p-1 self-start"
-          >
-            {courseLocked ? <Lock className="w-4 h-4 text-red-500" /> : <Unlock className="w-4 h-4 text-gray-400" />}
-          </button>
+          <div className="p-1 self-start">
+            {isLocked ? <Lock className="w-4 h-4 text-red-500" /> : <Unlock className="w-4 h-4 text-gray-400" />}
+          </div>
           <div className="mt-1 leading-tight">
             <div className="font-bold text-sm text-neu8 mb-1">{courseId}</div>
             <div className="text-sm text-neu7">{courseName}</div>

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -11,8 +11,6 @@ import { getCourseColorMap, getCourseKey } from "@/lib/scheduler/courseColors";
 import { FilterMultiSelect } from "./FilterMultiSelect";
 import { Switch } from "../ui/switch";
 import { TimeInput } from "./TimeInput";
-import { MoveRightIcon } from "lucide-react";
-import FeedbackModal from "../feedback/FeedbackModal";
 
 // Convert time string (e.g., "09:00") to military format (e.g., 900)
 function timeStringToMilitary(timeStr: string): number {
@@ -54,8 +52,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
       onFiltersChange({ ...filters, [key]: value });
     }
   };
-
-  const clearFilters = () => onFiltersChange({ includesOnline: true });
 
   const handleGenerate = () => {
     // Parse locked course IDs from input
@@ -110,67 +106,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
       >
         {isGenerating ? "Generating..." : "Generate Schedules"}
       </Button>
-
-      <Separator />
-
-      <div className="flex items-center justify-between">
-        <h3 className="text-muted-foreground text-xs font-bold">FILTERS</h3>
-        <button
-          onClick={clearFilters}
-          className="rounded bg-red-100 px-3 py-1 text-xs text-red-700 hover:bg-red-200"
-        >
-          Clear All
-        </button>
-      </div>
-
-      <Separator />
-
-      {/* Classes Filter*/}
-      <div className="flex justify-between items-center">
-        <h3 className="text-muted-foreground text-xs font-bold">CLASSES</h3>
-        <button
-          onClick={() => {}}
-          aria-label="Edit classes"
-          title="Edit classes"
-          className="p-1 border border-transparent text-gray-600 rounded"
-        >
-          <Pencil className="w-4 h-4" />
-        </button>
-      </div>
-
-      <div>
-        {filteredSchedules && filteredSchedules.length > 0 && (
-          (() => {
-            // Build a map of course -> sections
-            const courseMap = new Map<string, Map<string, SectionWithCourse>>();
-            for (const schedule of filteredSchedules) {
-              for (const section of schedule) {
-                const courseKey = getCourseKey(section);
-                if (!courseMap.has(courseKey)) courseMap.set(courseKey, new Map());
-                const inner = courseMap.get(courseKey)!;
-                if (!inner.has(section.crn)) inner.set(section.crn, section);
-              }
-            }
-
-            // Sort courses alphabetically
-            const courseEntries = Array.from(courseMap.entries()).sort((a, b) => a[0].localeCompare(b[0]));
-
-            return (
-              <div className="mt-2">
-                {courseEntries.map(([courseKey, sectionsMap]) => (
-                  <CourseBox
-                    key={courseKey}
-                    sections={Array.from(sectionsMap.values())}
-                    color={colorMap.get(courseKey)}
-                  />
-                ))}
-              </div>
-            );
-          })()
-        )}
-      </div>
-
-      <Separator />
 
       <Separator />
 

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -137,6 +137,21 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       <Separator />
 
+<<<<<<< HEAD
+=======
+      <div className="flex items-center justify-between">
+        <h3 className="text-muted-foreground text-xs font-bold">FILTERS</h3>
+        <button
+          onClick={clearFilters}
+          className="rounded bg-red-100 px-3 py-1 text-xs text-red-700 hover:bg-red-200"
+        >
+          Clear All
+        </button>
+      </div>
+
+      <Separator />
+
+>>>>>>> 3403d23 (fix: remove duplicate CLASSES section in FilterPanel)
       {/* Classes Filter*/}
       <div className="flex justify-between items-center">
         <h3 className="text-muted-foreground text-xs font-bold">CLASSES</h3>

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -11,6 +11,12 @@ import { getCourseColorMap, getCourseKey } from "@/lib/scheduler/courseColors";
 import { FilterMultiSelect } from "./FilterMultiSelect";
 import { Switch } from "../ui/switch";
 import { TimeInput } from "./TimeInput";
+<<<<<<< HEAD
+=======
+import { MoveRightIcon } from "lucide-react";
+import FeedbackModal from "../feedback/FeedbackModal";
+import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
+>>>>>>> f452f97 (feat: add course selection modal with improved UX)
 
 // Convert time string (e.g., "09:00") to military format (e.g., 900)
 function timeStringToMilitary(timeStr: string): number {
@@ -32,11 +38,14 @@ interface FilterPanelProps {
   isGenerating: boolean;
   nupathOptions: { label: string; value: string }[];
   filteredSchedules: SectionWithCourse[][];
+  term: string;
+  termName: string;
 }
 
-export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions, filteredSchedules }: FilterPanelProps) {
+export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions, filteredSchedules, term, termName }: FilterPanelProps) {
   const [lockedCourseIdsInput, setLockedCourseIdsInput] = useState("");
   const [optionalCourseIdsInput, setOptionalCourseIdsInput] = useState("");
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Memoize the color map so it's only computed when filteredSchedules changes
   const colorMap = useMemo(() => getCourseColorMap(filteredSchedules), [filteredSchedules]);
@@ -73,6 +82,25 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
   return (
     <div className="bg-background h-[calc(100vh-72px)] w-full space-y-4 overflow-y-scroll px-2.5 pt-2.5 pb-4">
+      {/* Add Courses Button */}
+      <Button
+        onClick={() => setIsModalOpen(true)}
+        disabled={isGenerating}
+        className="w-full"
+      >
+        Add Courses
+      </Button>
+
+      <AddCoursesModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+        term={term}
+        termName={termName}
+        onGenerateSchedules={(courseIds) => onGenerateSchedules(courseIds, [])}
+      />
+
+      <Separator />
+
       {/* Locked Course IDs Input */}
       <div>
         <Label className="text-muted-foreground text-xs font-bold">

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -40,9 +40,10 @@ interface FilterPanelProps {
   filteredSchedules: SectionWithCourse[][];
   term: string;
   termName: string;
+  lockedCourseKeys: string[];
 }
 
-export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions, filteredSchedules, term, termName }: FilterPanelProps) {
+export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions, filteredSchedules, term, termName, lockedCourseKeys }: FilterPanelProps) {
   const [lockedCourseIdsInput, setLockedCourseIdsInput] = useState("");
   const [optionalCourseIdsInput, setOptionalCourseIdsInput] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -96,7 +97,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         onOpenChange={setIsModalOpen}
         term={term}
         termName={termName}
-        onGenerateSchedules={(courseIds) => onGenerateSchedules(courseIds, [])}
+        onGenerateSchedules={onGenerateSchedules}
       />
 
       <Separator />
@@ -184,13 +185,19 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
             return (
               <div className="mt-2">
-                {courseEntries.map(([courseKey, sectionsMap]) => (
-                  <CourseBox
-                    key={courseKey}
-                    sections={Array.from(sectionsMap.values())}
-                    color={colorMap.get(courseKey)}
-                  />
-                ))}
+                {courseEntries.map(([courseKey, sectionsMap]) => {
+                  const sections = Array.from(sectionsMap.values());
+                  const isLocked = lockedCourseKeys.includes(courseKey);
+                  
+                  return (
+                    <CourseBox
+                      key={courseKey}
+                      sections={sections}
+                      color={colorMap.get(courseKey)}
+                      isLocked={isLocked}
+                    />
+                  );
+                })}
               </div>
             );
           })()

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -230,7 +230,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         </div>
 
         {/* Day number buttons */}
-        <div className="flex gap-2">
+        <div className="flex gap-2 justify-center">
           {[1, 2, 3, 4, 5, 6].map((num) => (
             <button
               key={num}

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -47,6 +47,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
   const [lockedCourseIdsInput, setLockedCourseIdsInput] = useState("");
   const [optionalCourseIdsInput, setOptionalCourseIdsInput] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedCourses, setSelectedCourses] = useState<any[]>([]);
 
   // Memoize the color map so it's only computed when filteredSchedules changes
   const colorMap = useMemo(() => getCourseColorMap(filteredSchedules), [filteredSchedules]);
@@ -98,6 +99,8 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         term={term}
         termName={termName}
         onGenerateSchedules={onGenerateSchedules}
+        initialSelectedCourses={selectedCourses}
+        onSelectedCoursesChange={setSelectedCourses}
       />
 
       <Separator />

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -47,7 +47,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
   const [lockedCourseIdsInput, setLockedCourseIdsInput] = useState("");
   const [optionalCourseIdsInput, setOptionalCourseIdsInput] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedCourses, setSelectedCourses] = useState<any[]>([]);
 
   // Memoize the color map so it's only computed when filteredSchedules changes
   const colorMap = useMemo(() => getCourseColorMap(filteredSchedules), [filteredSchedules]);
@@ -99,8 +98,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         term={term}
         termName={termName}
         onGenerateSchedules={onGenerateSchedules}
-        initialSelectedCourses={selectedCourses}
-        onSelectedCoursesChange={setSelectedCourses}
       />
 
       <Separator />

--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -5,18 +5,13 @@ import { type ScheduleFilters, type SectionWithCourse } from "@/lib/scheduler/fi
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
-import { Pencil } from "lucide-react";
+import { Plus, Pencil } from "lucide-react";
 import { CourseBox } from "@/components/scheduler/CourseBox";
 import { getCourseColorMap, getCourseKey } from "@/lib/scheduler/courseColors";
 import { FilterMultiSelect } from "./FilterMultiSelect";
 import { Switch } from "../ui/switch";
 import { TimeInput } from "./TimeInput";
-<<<<<<< HEAD
-=======
-import { MoveRightIcon } from "lucide-react";
-import FeedbackModal from "../feedback/FeedbackModal";
 import { AddCoursesModal } from "@/components/scheduler/AddCourseModal";
->>>>>>> f452f97 (feat: add course selection modal with improved UX)
 
 // Convert time string (e.g., "09:00") to military format (e.g., 900)
 function timeStringToMilitary(timeStr: string): number {
@@ -38,18 +33,19 @@ interface FilterPanelProps {
   isGenerating: boolean;
   nupathOptions: { label: string; value: string }[];
   filteredSchedules: SectionWithCourse[][];
+  allSchedules: SectionWithCourse[][];
   term: string;
   termName: string;
   lockedCourseKeys: string[];
 }
 
-export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions, filteredSchedules, term, termName, lockedCourseKeys }: FilterPanelProps) {
+export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isGenerating, nupathOptions, filteredSchedules, allSchedules, term, termName, lockedCourseKeys }: FilterPanelProps) {
   const [lockedCourseIdsInput, setLockedCourseIdsInput] = useState("");
   const [optionalCourseIdsInput, setOptionalCourseIdsInput] = useState("");
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  // Memoize the color map so it's only computed when filteredSchedules changes
-  const colorMap = useMemo(() => getCourseColorMap(filteredSchedules), [filteredSchedules]);
+  // Memoize the color map so it's only computed when allSchedules changes
+  const colorMap = useMemo(() => getCourseColorMap(allSchedules), [allSchedules]);
 
   const updateFilter = <K extends keyof ScheduleFilters>(
     key: K,
@@ -83,15 +79,6 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
   return (
     <div className="bg-background h-[calc(100vh-72px)] w-full space-y-4 overflow-y-scroll px-2.5 pt-2.5 pb-4">
-      {/* Add Courses Button */}
-      <Button
-        onClick={() => setIsModalOpen(true)}
-        disabled={isGenerating}
-        className="w-full"
-      >
-        Add Courses
-      </Button>
-
       <AddCoursesModal
         open={isModalOpen}
         onOpenChange={setIsModalOpen}
@@ -100,78 +87,29 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
         onGenerateSchedules={onGenerateSchedules}
       />
 
-      <Separator />
-
-      {/* Locked Course IDs Input */}
-      <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          LOCKED COURSE IDs
-        </Label>
-        <textarea
-          value={lockedCourseIdsInput}
-          onChange={(e) => setLockedCourseIdsInput(e.target.value)}
-          placeholder="Enter locked course IDs separated by commas (e.g., 2953, 160)"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2 min-h-[60px] font-mono text-sm"
-        />
-      </div>
-
-      {/* Optional Course IDs Input */}
-      <div>
-        <Label className="text-muted-foreground text-xs font-bold">
-          OPTIONAL COURSE IDs
-        </Label>
-        <textarea
-          value={optionalCourseIdsInput}
-          onChange={(e) => setOptionalCourseIdsInput(e.target.value)}
-          placeholder="Enter optional course IDs separated by commas (e.g., 142, 5857)"
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 mt-2 min-h-[60px] font-mono text-sm"
-        />
-      </div>
-
-      <Button
-        onClick={handleGenerate}
-        disabled={isGenerating}
-        className="w-full"
-      >
-        {isGenerating ? "Generating..." : "Generate Schedules"}
-      </Button>
-
-      <Separator />
-
-<<<<<<< HEAD
-=======
-      <div className="flex items-center justify-between">
-        <h3 className="text-muted-foreground text-xs font-bold">FILTERS</h3>
-        <button
-          onClick={clearFilters}
-          className="rounded bg-red-100 px-3 py-1 text-xs text-red-700 hover:bg-red-200"
-        >
-          Clear All
-        </button>
-      </div>
-
-      <Separator />
-
->>>>>>> 3403d23 (fix: remove duplicate CLASSES section in FilterPanel)
       {/* Classes Filter*/}
       <div className="flex justify-between items-center">
         <h3 className="text-muted-foreground text-xs font-bold">CLASSES</h3>
         <button
-          onClick={() => {}}
-          aria-label="Edit classes"
-          title="Edit classes"
-          className="p-1 border border-transparent text-gray-600 rounded"
+          onClick={() => setIsModalOpen(true)}
+          aria-label={allSchedules.length > 0 ? "Edit courses" : "Add courses"}
+          title={allSchedules.length > 0 ? "Edit courses" : "Add courses"}
+          className="text-muted-foreground hover:text-foreground transition-colors"
         >
-          <Pencil className="w-4 h-4" />
+          {allSchedules.length > 0 ? (
+            <Pencil className="size-5" />
+          ) : (
+            <Plus className="size-5" />
+          )}
         </button>
       </div>
 
       <div>
-        {filteredSchedules && filteredSchedules.length > 0 && (
+        {allSchedules && allSchedules.length > 0 && (
           (() => {
             // Build a map of course -> sections
             const courseMap = new Map<string, Map<string, SectionWithCourse>>();
-            for (const schedule of filteredSchedules) {
+            for (const schedule of allSchedules) {
               for (const section of schedule) {
                 const courseKey = getCourseKey(section);
                 if (!courseMap.has(courseKey)) courseMap.set(courseKey, new Map());

--- a/src/components/scheduler/SchedulerView.tsx
+++ b/src/components/scheduler/SchedulerView.tsx
@@ -3,27 +3,11 @@
 import { useState, useMemo, useEffect } from "react";
 import { type ScheduleFilters, type SectionWithCourse } from "@/lib/scheduler/filters";
 import { CalendarView } from "./CalendarView";
-import { getCourseColorMap, getCourseKey } from "@/lib/scheduler/courseColors";
-
-// Helper to convert time format (e.g., 1330 -> "1:30 PM")
-function formatTime(time: number): string {
-  const hours = Math.floor(time / 100);
-  const minutes = time % 100;
-  const period = hours >= 12 ? "PM" : "AM";
-  const displayHours = hours > 12 ? hours - 12 : hours === 0 ? 12 : hours;
-  return `${displayHours}:${minutes.toString().padStart(2, "0")} ${period}`;
-}
-
-// Helper to convert day numbers to day names
-// Days are stored as: 0=Sunday, 1=Monday, 2=Tuesday, 3=Wednesday, 4=Thursday, 5=Friday, 6=Saturday
-function formatDays(days: number[]): string {
-  const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-  return days.map((d) => dayNames[d]).join(", ");
-}
+import { getCourseColorMap } from "@/lib/scheduler/courseColors";
 
 // Helper to get unique courses from a schedule
 function getCoursesFromSchedule(schedule: SectionWithCourse[]): string[] {
-  const courses = schedule.map(section => 
+  const courses = schedule.map(section =>
     `${section.courseSubject} ${section.courseNumber}`
   );
   return Array.from(new Set(courses)).sort();
@@ -46,17 +30,17 @@ function getScheduleKey(schedule: SectionWithCourse[]): string {
 // Group schedules by their course combinations
 function groupSchedulesByCourses(schedules: SectionWithCourse[][]): Map<string, SectionWithCourse[][]> {
   const groups = new Map<string, SectionWithCourse[][]>();
-  
+
   for (const schedule of schedules) {
     const courses = getCoursesFromSchedule(schedule);
     const key = getCourseGroupKey(courses);
-    
+
     if (!groups.has(key)) {
       groups.set(key, []);
     }
     groups.get(key)!.push(schedule);
   }
-  
+
   return groups;
 }
 
@@ -71,7 +55,7 @@ export function SchedulerView({ schedules, filters }: SchedulerViewProps) {
 
   // Memoize the color map so it's only computed when schedules changes
   const colorMap = useMemo(() => getCourseColorMap(schedules), [schedules]);
-  
+
   // Group schedules by course combinations
   const courseGroups = useMemo(() => {
     const groups = groupSchedulesByCourses(schedules);
@@ -145,8 +129,8 @@ export function SchedulerView({ schedules, filters }: SchedulerViewProps) {
               onClick={() => handleCourseGroupChange(group.courseKey, index)}
               className={`
                 px-3 py-2 rounded-lg border whitespace-nowrap font-bold flex items-center gap-2 text-neu8
-                ${currentCourseGroupIndex === index 
-                  ? "border-neu3 bg-white" 
+                ${currentCourseGroupIndex === index
+                  ? "border-neu3 bg-white"
                   : "border-neu3 bg-neu2 hover:bg-neu3"
                 }
               `}
@@ -182,8 +166,8 @@ export function SchedulerView({ schedules, filters }: SchedulerViewProps) {
                 onClick={() => handleScheduleChange(scheduleKey)}
                 className={`
                   px-4 py-2 rounded-lg border whitespace-nowrap font-bold
-                  ${currentScheduleIndex === index 
-                    ? "bg-white border-gray-300 text-gray-900" 
+                  ${currentScheduleIndex === index
+                    ? "bg-white border-gray-300 text-gray-900"
                     : "bg-gray-100 border-gray-300 text-gray-600 hover:bg-gray-200"
                   }
                 `}

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -13,7 +13,7 @@ interface SchedulerWrapperProps {
 
 export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
   const router = useRouter();
-  const [filters, setFilters] = useState<ScheduleFilters>({includesOnline: true, includeHonors: true});
+  const [filters, setFilters] = useState<ScheduleFilters>({ includesOnline: true, includeHonors: true });
   const [isPending, startTransition] = useTransition();
 
   const handleGenerateSchedules = async (lockedCourseIds: number[], optionalCourseIds: number[]) => {
@@ -38,8 +38,8 @@ export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerW
   return (
     <div className="grid w-full grid-cols-6">
       <div className="col-span-1 w-full">
-        <FilterPanel 
-          filters={filters} 
+        <FilterPanel
+          filters={filters}
           onFiltersChange={setFilters}
           onGenerateSchedules={handleGenerateSchedules}
           isGenerating={isPending}

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -11,9 +11,10 @@ interface SchedulerWrapperProps {
   nupathOptions: { label: string; value: string }[];
   term: string;
   termName: string;
+  lockedCourseKeys: string[];
 }
 
-export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termName }: SchedulerWrapperProps) {
+export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termName, lockedCourseKeys }: SchedulerWrapperProps) {
   const router = useRouter();
   const [filters, setFilters] = useState<ScheduleFilters>({ includesOnline: true, includeHonors: true });
   const [isPending, startTransition] = useTransition();
@@ -49,6 +50,7 @@ export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termNa
           filteredSchedules={filteredSchedules}
           term={term}
           termName={termName}
+          lockedCourseKeys={lockedCourseKeys}
         />
       </div>
       <div className="col-span-5 pl-6">

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -41,13 +41,14 @@ export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termNa
   return (
     <div className="grid w-full grid-cols-6">
       <div className="col-span-1 w-full">
-        <FilterPanel
-          filters={filters}
+        <FilterPanel 
+          filters={filters} 
           onFiltersChange={setFilters}
           onGenerateSchedules={handleGenerateSchedules}
           isGenerating={isPending}
           nupathOptions={nupathOptions}
           filteredSchedules={filteredSchedules}
+          allSchedules={initialSchedules}
           term={term}
           termName={termName}
           lockedCourseKeys={lockedCourseKeys}

--- a/src/components/scheduler/SchedulerWrapper.tsx
+++ b/src/components/scheduler/SchedulerWrapper.tsx
@@ -9,9 +9,11 @@ import { FilterPanel } from "./FilterPanel";
 interface SchedulerWrapperProps {
   initialSchedules: SectionWithCourse[][];
   nupathOptions: { label: string; value: string }[];
+  term: string;
+  termName: string;
 }
 
-export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerWrapperProps) {
+export function SchedulerWrapper({ initialSchedules, nupathOptions, term, termName }: SchedulerWrapperProps) {
   const router = useRouter();
   const [filters, setFilters] = useState<ScheduleFilters>({ includesOnline: true, includeHonors: true });
   const [isPending, startTransition] = useTransition();
@@ -45,6 +47,8 @@ export function SchedulerWrapper({ initialSchedules, nupathOptions }: SchedulerW
           isGenerating={isPending}
           nupathOptions={nupathOptions}
           filteredSchedules={filteredSchedules}
+          term={term}
+          termName={termName}
         />
       </div>
       <div className="col-span-5 pl-6">

--- a/src/components/scheduler/SectionDetailPopover.tsx
+++ b/src/components/scheduler/SectionDetailPopover.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import React from "react"
+
+import type { SectionWithCourse } from "@/lib/scheduler/filters"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+
+interface SectionDetailPopoverProps {
+  section: SectionWithCourse,
+  children: React.ReactNode
+}
+
+export function SectionDetailPopover({ section, children }: SectionDetailPopoverProps) {
+
+  const isOnline = section.campus === "Online";
+  const meetingTime = section.meetingTimes?.[0]
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent className="w-[360px] p-0 border-gray-200 shadow-lg" align="start" side="right" sideOffset={8}>
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 relative bg-gray-50 rounded-t-xl">
+          <h2 className="text-xl font-bold text-gray-900">
+            {section.courseSubject} {section.courseNumber}
+          </h2>
+          <p className="text-sm text-gray-500 mt-1">{section.courseName}</p>
+        </div>
+
+        {/* Content */}
+        <div className="pt-2 pb-4 px-6">
+          <table className="w-full">
+            <tbody>
+              {/* CRN */}
+              <tr className="h-12">
+                <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-middle">CRN</td>
+                <td className="text-base text-gray-900 align-middle">{section.crn}</td>
+              </tr>
+
+              {/* Seats / Waitlist */}
+              <tr className="h-12">
+                <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-middle">Seats | Waitlist</td>
+                <td className="align-middle">
+                  <div className="flex gap-2">
+                    <span className="px-3 py-1 rounded-full bg-green-50 text-green-600 text-sm font-medium">
+                      {section.seatRemaining ?? 0}/{section.seatCapacity ?? 0}
+                    </span>
+                    <span className="px-3 py-1 rounded-full bg-gray-100 text-gray-600 text-sm font-medium">
+                      {section.waitlistRemaining ?? 0}/{section.waitlistCapacity ?? 0}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+
+              {/* Meeting Times */}
+              <tr>
+                <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-top pt-4">Meeting Times</td>
+                <td className="pt-4 pb-2">
+                  {isOnline ? (
+                    <span className="text-sm italic text-gray-500">Asynchronous</span>
+                  ) : (
+                    <>
+                      <div className="text-base text-gray-900 mb-1">
+                        {formatMeetingDays(meetingTime.days)}
+                      </div>
+                      <div className="text-sm text-gray-600">
+                        {formatTime(meetingTime.startTime)}–{formatTime(meetingTime.endTime)}
+                      </div>
+                    </>
+                  )}
+                </td>
+              </tr>
+
+              {/* Room */}
+              {!isOnline && (
+                <tr className="h-12">
+                  <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-middle">Room</td>
+                  <td className="text-base text-gray-900 align-middle">{parseSectionRoom(section)}</td>
+                </tr>
+              )}
+
+              {/* Professor */}
+              {section.faculty && (
+                <tr className="h-12">
+                  <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-middle">Professor</td>
+                  <td className="text-base text-gray-900 align-middle">{section.faculty}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+const formatMeetingDays = (meetingDays: number[]): React.ReactNode => {
+  const meetsOnWeekend = meetingDays.includes(0) || meetingDays.includes(6)
+
+  const dayLabels = meetsOnWeekend
+    ? ["S", "M", "T", "W", "TH", "F", "S"]
+    : ["M", "T", "W", "TH", "F"]
+
+  const dayIndices = meetsOnWeekend
+    ? [0, 1, 2, 3, 4, 5, 6]
+    : [1, 2, 3, 4, 5]
+
+  return (
+    <span className="tracking-wide">
+      {dayIndices.map((dayIndex, idx) => {
+        const isMeetingDay = meetingDays.includes(dayIndex)
+        return (
+          <React.Fragment key={dayIndex}>
+            {idx > 0 && " "}
+            <span className={isMeetingDay ? "font-bold text-gray-900" : "text-gray-400"}>
+              {dayLabels[meetsOnWeekend ? dayIndex : dayIndex - 1]}
+            </span>
+          </React.Fragment>
+        )
+      })}
+    </span>
+  )
+}
+
+const parseSectionRoom = (section: SectionWithCourse): string => {
+  if (section.campus === "Online") {
+    return "Online";
+  }
+
+  const room = section.meetingTimes[0]?.room;
+  if (room?.building) {
+    return `${room.building.name} ${room.number}`;
+  }
+
+  return "TBA";
+}
+
+const formatTime = (time: number): string => {
+  const hours = Math.floor(time / 100)
+  const minutes = time % 100
+  const period = hours >= 12 ? "PM" : "AM"
+  const displayHours = hours > 12 ? hours - 12 : hours === 0 ? 12 : hours
+  return `${displayHours}:${minutes.toString().padStart(2, "0")} ${period}`
+}

--- a/src/components/scheduler/SectionDetailPopover.tsx
+++ b/src/components/scheduler/SectionDetailPopover.tsx
@@ -12,7 +12,7 @@ interface SectionDetailPopoverProps {
 
 export function SectionDetailPopover({ section, children }: SectionDetailPopoverProps) {
 
-  const isOnline = section.campus === "Online";
+  const isScheduled = section.meetingTimes && section.meetingTimes.length > 0
   const meetingTime = section.meetingTimes?.[0]
 
   return (
@@ -56,7 +56,7 @@ export function SectionDetailPopover({ section, children }: SectionDetailPopover
               <tr>
                 <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-top pt-4">Meeting Times</td>
                 <td className="pt-4 pb-2">
-                  {isOnline ? (
+                  {!isScheduled ? (
                     <span className="text-sm italic text-gray-500">Asynchronous</span>
                   ) : (
                     <>
@@ -72,12 +72,10 @@ export function SectionDetailPopover({ section, children }: SectionDetailPopover
               </tr>
 
               {/* Room */}
-              {!isOnline && (
-                <tr className="h-12">
-                  <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-middle">Room</td>
-                  <td className="text-base text-gray-900 align-middle">{parseSectionRoom(section)}</td>
-                </tr>
-              )}
+              <tr className="h-12">
+                <td className="text-sm font-medium text-gray-400 uppercase tracking-wide align-middle">Room</td>
+                <td className="text-base text-gray-900 align-middle">{parseSectionRoom(section)}</td>
+              </tr>
 
               {/* Professor */}
               {section.faculty && (

--- a/src/lib/controllers/getTerms.ts
+++ b/src/lib/controllers/getTerms.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { db } from "@/db";
 import { termsT } from "@/db/schema";
+import { eq } from "drizzle-orm";
 import type { GroupedTerms } from "../types";
 
 // getTerms retreives all the terms from the db
@@ -36,4 +37,15 @@ export async function getTerms() {
   groupedTerms.law.sort((a, b) => b.term.localeCompare(a.term));
 
   return groupedTerms;
+}
+
+// getTermName retrieves the display name for a specific term
+export async function getTermName(termId: string) {
+  const result = await db
+    .select({ name: termsT.name })
+    .from(termsT)
+    .where(eq(termsT.term, termId))
+    .limit(1);
+
+  return result[0]?.name ?? termId;
 }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -20,6 +20,6 @@ export const schedulerFlag = flag({
   key: "scheduler",
   description: "Enable scheduler page",
   decide() {
-    return false;
+    return true;
   },
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { Requisite } from "@/scraper/reqs";
+
 export interface Term {
   term: string;
   name: string;
@@ -12,4 +14,24 @@ export interface GroupedTerms {
 export interface Subject {
   label: string;
   value: string;
+}
+
+export interface CourseSearchResult {
+  id: number;
+  name: string;
+  courseNumber: string;
+  subject: string;
+  maxCredits: string;
+  minCredits: string;
+  nupaths: string[];
+  nupathNames: string[];
+  prereqs: Requisite;
+  coreqs: Requisite;
+  postreqs: Requisite;
+  totalSections: number;
+  sectionsWithSeats: number;
+  campus: string[];
+  classType: string[];
+  honors: boolean;
+  score: number;
 }


### PR DESCRIPTION
REBASED ON MAIN

Summary
     - Implements the Add Courses modal on the catalog page with full course selection functionality.
     
Changes
     - New `AddCoursesModal` component with two-column layout
     - Real-time course search via `/api/search` endpoint
     - Course selection (add/remove, max 10 courses)
     - Lock/unlock toggle for selected courses
     - Generate schedules button (navigates to scheduler page)
     - Term display name conversion (shows "Spring 2026" instead of "202630")
     - Loading states and error handling
     - Backend API integration with debounced search
     
Testing
     - [x] Modal opens from catalog page
     - [x] Course search works with real API data
     - [x] Add/remove courses functionality
     - [x] Lock/unlock toggle works
     - [x] Generate schedules navigates correctly
     - [x] Term display name shows correctly
     
Future Work (not in this PR)
     - Campus filtering (placeholder implemented)
     - Child sections (recitations/labs)
     - Info button functionality

![0FCC8BE5-4157-4198-84D9-8260A10C710B](https://github.com/user-attachments/assets/ca378109-6708-469d-b6f9-1a2155dadd81)