### PR TITLE
feat: Banner change notif outage header

### DIFF
--- a/src/components/navigation/BannerWarning.tsx
+++ b/src/components/navigation/BannerWarning.tsx
@@ -1,0 +1,11 @@
+export function BannerWarning() {
+  return (
+    <div className="bg-red text-neu1 -mt-4 mb-4 flex w-full flex-col items-center justify-center gap-2 px-4 py-2 md:flex-row">
+      <h3 className="text-lg font-bold">Notification Outage</h3>
+      <p className="text-center md:text-left">
+        Due to changes in Banner by the University, we are unable to send any
+        seat tracking notifications. We are working to solve this issue.
+      </p>
+    </div>
+  );
+}

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -13,6 +13,7 @@ import {
 } from "../ui/sheet";
 import { Button } from "../ui/button";
 import { NavBar } from "./NavBar";
+import { BannerWarning } from "./BannerWarning";
 
 export function Header() {
   const enableFaqPage = faqFlag();
@@ -32,39 +33,42 @@ export function Header() {
   );
 
   return (
-    <header className="z-20 flex h-9 w-full items-center justify-between bg-transparent px-4 md:px-6">
-      <Link href="/">
-        <Logo className="h-6 w-40" />
-      </Link>
-      <div className="hidden items-center gap-2 lg:flex">
-        {Nav}
-        <UserIcon />
-      </div>
-      <Sheet>
-        <SheetTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="bg-neu1 rounded-full border lg:hidden"
-          >
-            <MenuIcon className="text-neu8 size-5" />
-          </Button>
-        </SheetTrigger>
-        <SheetContent className="bg-neu2 flex w-[90%] flex-col justify-between px-6 pt-6 pb-4">
-          <SheetTitle className="hidden">Nav bar</SheetTitle>
-          <div className="flex flex-col gap-8">
-            <Link href="/">
-              <Logo className="h-6 w-40" />
-            </Link>
-            <UserIcon />
-            {Nav}
-          </div>
-          <SheetClose className="bg-neu1 absolute top-4 right-4 flex size-9 items-center justify-center rounded-full border disabled:pointer-events-none">
-            <XIcon className="size-6" />
-            <span className="sr-only">Close</span>
-          </SheetClose>
-        </SheetContent>
-      </Sheet>
-    </header>
+    <>
+      <BannerWarning />
+      <header className="z-20 flex h-9 w-full items-center justify-between bg-transparent px-4 md:px-6">
+        <Link href="/">
+          <Logo className="h-6 w-40" />
+        </Link>
+        <div className="hidden items-center gap-2 lg:flex">
+          {Nav}
+          <UserIcon />
+        </div>
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="bg-neu1 rounded-full border lg:hidden"
+            >
+              <MenuIcon className="text-neu8 size-5" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent className="bg-neu2 flex w-[90%] flex-col justify-between px-6 pt-6 pb-4">
+            <SheetTitle className="hidden">Nav bar</SheetTitle>
+            <div className="flex flex-col gap-8">
+              <Link href="/">
+                <Logo className="h-6 w-40" />
+              </Link>
+              <UserIcon />
+              {Nav}
+            </div>
+            <SheetClose className="bg-neu1 absolute top-4 right-4 flex size-9 items-center justify-center rounded-full border disabled:pointer-events-none">
+              <XIcon className="size-6" />
+              <span className="sr-only">Close</span>
+            </SheetClose>
+          </SheetContent>
+        </Sheet>
+      </header>
+    </>
   );
 }


### PR DESCRIPTION
add a header explaining the banner api changes and subsequent scraper outage. the impact is an inability to scrape or update until the new endpoints are reverse-engineered; the most important impact is no notifications will be sent until scraping is restored.

depending on the magnitude of the changes, it may be worthwhile to block new tracker sign-ups as well as hide seat counts until the new scraper is made.

this PR is queued until the breaking changes are confirmed. since I highly suspect the changes wanted to have something up ready to merge, and close the PR if there are no changes, than scramble to patch and approve day-of.