### PR TITLE
validate time inputs

### DIFF
--- a/src/components/scheduler/FilterPanel.tsx
+++ b/src/components/scheduler/FilterPanel.tsx
@@ -245,7 +245,20 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
 
       {/* Time Section */}
       <div className="space-y-3">
-        <Label className="text-muted-foreground text-xs font-bold">TIME</Label>
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-xs font-bold">TIME</Label>
+          {(filters.startTime || filters.endTime) && (
+            <button
+              onClick={() => {
+                const { startTime: _, endTime: __, ...rest } = filters;
+                onFiltersChange(rest);
+              }}
+              className="text-blue-600 hover:text-blue-600/80 text-xs"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
         
         <div className="flex items-center justify-between text-sm pb-1.5">
           <span className="text-muted-foreground whitespace-nowrap">Start time is after</span>
@@ -259,6 +272,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
                 value ? timeStringToMilitary(value) : undefined
               )
             }
+            disableAfter={filters.endTime ? militaryToTimeString(filters.endTime) : undefined}
           />
         </div>
 
@@ -272,6 +286,7 @@ export function FilterPanel({ filters, onFiltersChange, onGenerateSchedules, isG
                 value ? timeStringToMilitary(value) : undefined
               )
             }
+            disableBefore={filters.startTime ? militaryToTimeString(filters.startTime) : undefined}
           />
         </div>        
       </div>

--- a/src/components/scheduler/TimeInput.tsx
+++ b/src/components/scheduler/TimeInput.tsx
@@ -22,6 +22,8 @@ interface TimeInputProps {
   startHour?: number;
   endHour?: number;
   intervalMinutes?: number;
+  disableAfter?: string; // Disable times after or equal this value (format: "HH:MM")
+  disableBefore?: string; // Disable times before or equal to this value (format: "HH:MM")
 }
 
 function generateTimeOptions(
@@ -54,6 +56,8 @@ export function TimeInput({
   startHour = 6,
   endHour = 24,
   intervalMinutes = 15,
+  disableAfter,
+  disableBefore,
 }: TimeInputProps) {
   const [open, setOpen] = useState(false);
   
@@ -61,6 +65,13 @@ export function TimeInput({
   
   const selectedOption = timeOptions.find((option) => option.value === value);
   const displayValue = selectedOption?.label || "-- : -- --";
+
+  // Helper to check if a time should be disabled
+  const isTimeDisabled = (timeValue: string): boolean => {
+    if (disableAfter && timeValue >= disableAfter) return true;
+    if (disableBefore && timeValue <= disableBefore) return true;
+    return false;
+  };
 
   return (      
       <Popover open={open} onOpenChange={setOpen}>
@@ -76,23 +87,30 @@ export function TimeInput({
             <CommandList>
               <CommandEmpty>No time found.</CommandEmpty>
               <CommandGroup>
-                {timeOptions.map((option) => (
-                  <CommandItem
-                    key={option.value}
-                    value={option.label}
-                    onSelect={() => {
-                      onChange(option.value);
-                      setOpen(false);
-                    }}
-                  >
-                    <Check
-                      className={`mr-2 h-4 w-4 ${
-                        option.value === value ? "opacity-100" : "opacity-0"
-                      }`}
-                    />
-                    {option.label}
-                  </CommandItem>
-                ))}
+                {timeOptions.map((option) => {
+                  const disabled = isTimeDisabled(option.value);
+                  return (
+                    <CommandItem
+                      key={option.value}
+                      value={option.label}
+                      disabled={disabled}
+                      onSelect={() => {
+                        if (!disabled) {
+                          onChange(option.value);
+                          setOpen(false);
+                        }
+                      }}
+                      className={disabled ? "opacity-50 cursor-not-allowed" : ""}
+                    >
+                      <Check
+                        className={`mr-6 h-4 w-4 ${
+                          option.value === value ? "opacity-100" : "opacity-0"
+                        }`}
+                      />
+                      {option.label}
+                    </CommandItem>
+                  );
+                })}
               </CommandGroup>
             </CommandList>
           </Command>


### PR DESCRIPTION
Closes #184 

If 7 AM start time is selected, then all end times on or before 7 AM are disabled, and vice versa for other way around. And add a clear all button so that the time filters can be cleared.
<img width="558" height="841" alt="image" src="https://github.com/user-attachments/assets/264f8414-936b-4b30-b658-7dbad10df6bc" />
