### PR TITLE
236 graduate api client

### DIFF
--- a/apps/searchneu/app/graduate/page.tsx
+++ b/apps/searchneu/app/graduate/page.tsx
@@ -1,3 +1,18 @@
+"use client";
+
+import { useSupportedMajors } from "../../lib/graduate/useGraduateApi";
+
 export default function Page() {
-  return <div>Hello graduates!</div>
+  const { data, error } = useSupportedMajors();
+
+  if (error) return <div>Error: {error.message}</div>;
+  if (!data) return <div>No data available</div>;
+
+  return (
+    <div>
+      <h1>Hello graduates!</h1>
+      <h2>Supported Majors:</h2>
+      <pre>{JSON.stringify(data.supportedMajors, null, 2)}</pre>
+    </div>
+  );
 }

--- a/apps/searchneu/lib/graduate/api-response-types.ts
+++ b/apps/searchneu/lib/graduate/api-response-types.ts
@@ -1,0 +1,26 @@
+import {
+  SupportedMajors,
+  MetaInfo,
+  Maybe,
+  SupportedMinors,
+} from "./types";
+
+/** Types our API responds with. */
+export interface GetSupportedMajorsResponse {
+  // { year => { majorName => {concentrations, minRequiredConcentrations} }}
+  supportedMajors: SupportedMajors;
+}
+
+export interface GetSupportedMinorsResponse {
+  supportedMinors: SupportedMinors;
+}
+
+export interface GetMetaInfoResponse extends MetaInfo {
+  commit: Maybe<string>;
+  commitMessage: Maybe<string>;
+  build_timestamp: Maybe<number>;
+  environment: Maybe<string>;
+}
+
+
+

--- a/apps/searchneu/lib/graduate/graduateApiClient.ts
+++ b/apps/searchneu/lib/graduate/graduateApiClient.ts
@@ -1,0 +1,79 @@
+import { GetMetaInfoResponse, GetSupportedMajorsResponse, GetSupportedMinorsResponse } from "./api-response-types";
+import { Major, Minor } from "./types";
+
+class GraduateAPIClient {
+  private baseURL: string;
+
+  constructor(baseURL?: string) {
+    this.baseURL = baseURL ?? (
+      process.env.NODE_ENV === 'development' 
+        ? '/api/graduate'
+        : 'https://api.graduatenu.com/api' 
+    );
+  }
+
+  private async req<T>(
+    method: string,
+    url: string,
+    body?: any,
+    params?: Record<string, string | number>
+  ): Promise<T> {
+    const base = typeof window !== 'undefined' ? window.location.origin : '';
+    const fullUrl = new URL(`${this.baseURL}${url}`, base);
+    
+    if (params) {
+      Object.keys(params).forEach(key => 
+        fullUrl.searchParams.append(key, String(params[key]))
+      );
+    }
+
+    const response = await fetch(fullUrl.toString(), {
+      method,
+      headers: { 
+        "Content-Type": "application/json" 
+      },
+      credentials: 'include',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  meta = {
+    getInfo: (): Promise<GetMetaInfoResponse> =>
+      this.req("GET", "/meta/info"),
+  };
+
+  majors = {
+    getSupportedMajors: (): Promise<GetSupportedMajorsResponse> =>
+      this.req("GET", "/majors/supportedMajors"),
+    
+    get: (catalogYear: number, majorName: string): Promise<Major> =>
+      this.req("GET", `/majors/${catalogYear}/${majorName}`),
+  };
+
+  minors = {
+    get: (catalogYear: number, minorName: string): Promise<Minor> =>
+      this.req("GET", `/minors/${catalogYear}/${minorName}`),
+    
+    getSupportedMinors: (): Promise<GetSupportedMinorsResponse> =>
+      this.req("GET", "/minors/supportedMinors"),
+  };
+
+  templates = {
+    getForYear: (catalogYear: number): Promise<Record<string, Major>> =>
+      this.req("GET", `/templates/${catalogYear}`),
+    
+    getForMajor: (majorName: string, catalogYear: number): Promise<Major | null> =>
+      this.req("GET", `/templates/${catalogYear}/${majorName}`),
+    
+    getAll: (): Promise<Record<string, Record<string, Major>>> =>
+      this.req("GET", "/templates"),
+  };
+}
+
+export const GraduateAPI = new GraduateAPIClient();

--- a/apps/searchneu/lib/graduate/types.ts
+++ b/apps/searchneu/lib/graduate/types.ts
@@ -159,3 +159,199 @@ export interface ScheduleYear<T> {
 export interface Schedule<T> {
     years: ScheduleYear<T>[];
 }
+
+/**
+ * A Major, containing all the requirements.
+ *
+ * @param name                 The name of the major.
+ * @param requirementSections  A list of the sections of requirements.
+ * @param totalCreditsRequired Total credits required to graduate with this major.
+ * @param yearVersion          The catalog version year of this major.
+ * @param concentrations       The possible concentrations within this major.
+ */
+export interface Major {
+    name: string;
+    requirementSections: Section[];
+    totalCreditsRequired: number;
+    yearVersion: number;
+    concentrations?: Concentrations;
+    metadata?: MajorMetadata;
+  }
+
+  /**
+ * Metadata for a major.
+ *
+ * @param verified   Whether the major has been manually verified.
+ * @param lastEdited The last time the major was edited MM/DD/YYYY.
+ * @param branch     The branch of the scraper (must be main).
+ */
+export interface MajorMetadata {
+    verified: boolean;
+    lastEdited: string;
+    branch: string;
+  }
+
+/**
+ * A Minor, containing all the requirements.
+ *
+ * @param name                 The name of the minor.
+ * @param requirementSections  A list of the sections of requirements.
+ * @param totalCreditsRequired Total credits required to graduate with this minor.
+ * @param yearVersion          The catalog version year of this minor.
+ * @param metadata             Metadata for the minor.
+ */
+
+export interface Minor {
+    name: string;
+    requirementSections: Section[];
+    totalCreditsRequired: number;
+    yearVersion: number;
+    metadata?: MinorMetaData;
+  }
+
+/**
+ * Metadata for a minor.
+ *
+ * @param verified   Whether the major has been manually verified.
+ * @param lastEdited The last time the major was edited MM/DD/YYYY.
+ * @param branch     The branch of the scraper (must be main).
+ */
+export interface MinorMetaData {
+    verified: boolean;
+    lastEdited: string;
+    branch: string;
+  }
+
+  /**
+  * A Concentrations, contains all of the available concentrations for the major
+  * and their respective requirements.
+  
+  * @param minOptions           The minimum number of concentrations required for
+  *   the major.
+  * @param concentrationOptions The list of sections representing all of the
+  *   available concentrations in the major.
+  */
+  export interface Concentrations {
+    minOptions: number;
+    concentrationOptions: Section[];
+  }
+
+ /**
+  * A Section, containing its related requirements.
+  *
+  * @param title               The title of the section.
+  * @param requirements        A list of the requirements within this section.
+  * @param minRequirementCount The minimum number of requirements (counts from
+  *   requirements) that are accepted for the section to be fulfilled.
+  */
+  export interface Section {
+    type: "SECTION";
+    title: string;
+    requirements: Requirement[];
+    minRequirementCount: number;
+    warnings?: string[];
+  }
+
+ /** Represents a degree requirement that allows a Section to be completed. */
+ export type Requirement =
+    | IXofManyCourse
+    | IAndCourse
+    | IOrCourse
+    | ICourseRange
+    | IRequiredCourse
+    | Section;
+
+/**
+ * Represents a requirement where X number of credits need to be completed from
+ * a list of courses.
+ *
+ * @param type          The type of requirement.
+ * @param numCreditsMin The minimum number of credits needed to fulfill a given section.
+ * @param courses       The list of requirements that the credits can be fulfilled from.
+ */
+export interface IXofManyCourse {
+    type: "XOM";
+    numCreditsMin: number;
+    courses: Requirement[];
+  }
+  
+  /**
+   * Represents an 'AND' series of requirements.
+   *
+   * @param type    The type of requirement.
+   * @param courses The list of requirements, all of which must be taken to
+   *   satisfy this requirement.
+   */
+  export interface IAndCourse {
+    type: "AND";
+    courses: Requirement[];
+  }
+  
+  /**
+   * Represents an 'OR' set of requirements.
+   *
+   * @param type    The type of requirement.
+   * @param courses The list of requirements, one of which can be taken to satisfy
+   *   this requirement.
+   */
+  export interface IOrCourse {
+    type: "OR";
+    courses: Requirement[];
+  }
+  
+  /**
+   * Represents a requirement that specifies a range of courses.
+   *
+   * @param type         The type of requirement.
+   * @param subject      The subject area of the range of courses.
+   * @param idRangeStart The course ID for the starting range of course numbers.
+   * @param idRangeEnd   The course ID for the ending range of course numbers.
+   * @param exceptions   The requirements within the mentioned range that do not
+   *   count towards fulfulling this requirement.
+   */
+  export interface ICourseRange {
+    type: "RANGE";
+    subject: string;
+    idRangeStart: number;
+    idRangeEnd: number;
+    exceptions: IRequiredCourse[];
+  }
+  
+  /**
+   * A single required course.
+   *
+   * @param classId - The numeric ID of the course.
+   * @param subject - The subject that the course is concerned with, such as CS
+   *   (Computer Science).
+   */
+  export interface IRequiredCourse {
+    type: "COURSE";
+    classId: number;
+    subject: string;
+    description?: string;
+  }
+
+
+  export type SupportedConcentrations = {
+    concentrations: string[];
+    minRequiredConcentrations: number;
+    verified: boolean;
+  };
+
+  // { majorName => { concentration, minRequiredConcentrations, verified} }
+  export type SupportedMajorsForYear = Record<string, SupportedConcentrations>;
+  export type SupportedMinorsForYear = Record<string, Minor>;
+
+  // { year => supported majors }
+  export type SupportedMajors = Record<string, SupportedMajorsForYear>;
+  export type SupportedMinors = Record<string, SupportedMinorsForYear>;
+  
+  export type Maybe<T> = T | false;
+  
+  export interface MetaInfo {
+    commit: Maybe<string>;
+    commitMessage: Maybe<string>;
+    build_timestamp: Maybe<number>;
+    environment: Maybe<string>;
+  }
+  

--- a/apps/searchneu/lib/graduate/useGraduateApi.ts
+++ b/apps/searchneu/lib/graduate/useGraduateApi.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+import { GraduateAPI } from './graduateApiClient';
+import { GetSupportedMajorsResponse } from './api-response-types';
+
+export function useSupportedMajors() {
+  const [data, setData] = useState<GetSupportedMajorsResponse | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchMajors = async () => {
+      try {
+        const response = await GraduateAPI.majors.getSupportedMajors();
+        setData(response);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch majors'));
+      } finally {
+      }
+    };
+
+    fetchMajors();
+  }, []);
+
+  return { data, error };
+}

--- a/apps/searchneu/next.config.ts
+++ b/apps/searchneu/next.config.ts
@@ -12,6 +12,15 @@ const nextConfig: NextConfig = {
   // cacheComponents: true, /* BUG: unstable for the time being */
   reactCompiler: true,
 
+  async rewrites() {
+    return [
+      {
+        source: "/api/graduate/:path*",
+        destination: "https://api.graduatenu.com/api/:path*",
+      },
+    ];
+  },
+
   async redirects() {
     return [
       {


### PR DESCRIPTION
# Pull Request - Graduate API Client

Adding more necessary graduate types as well as api response types. This ticket also includes the graduate api client. Lmk if anyone thinks there should be file rearrangements I kind of just placed things where it felt intuitive but am not actually 100% on search standards.

This graduate API client can make requests to the graduate backend for non-user specific requests ie getting supported majors and minors. There may be additional endpoints that need to be added as development continues

Checkout to branch to see an example of a graduate endpoint being called on the graduate page frontend

<img width="882" height="793" alt="Screenshot 2026-01-28 at 4 44 21 PM" src="https://github.com/user-attachments/assets/b2db0568-8f31-44a0-92d9-a10ae2dfb68f" />

