### PR TITLE
294 alex graduate guest mode

### DIFF
--- a/apps/searchneu/app/graduate/[planId]/page.tsx
+++ b/apps/searchneu/app/graduate/[planId]/page.tsx
@@ -155,7 +155,7 @@ export default async function PlanPage({
 
   return (
     <div className="mx-auto flex flex-col gap-4 px-6">
-      <HeaderClient plans={userPlans} currentPlan={hydrated} />
+      <HeaderClient plans={userPlans} currentPlan={hydrated} isGuest={false} />
       <PlanClient plan={hydrated} courseNames={hydrated.courseNames} />
     </div>
   );

--- a/apps/searchneu/app/graduate/page.tsx
+++ b/apps/searchneu/app/graduate/page.tsx
@@ -1,9 +1,14 @@
 import NewPlanModal from "@/components/graduate/modal/NewPlanModal";
+import { auth } from "@/lib/auth/auth";
+import { headers } from "next/headers";
 
-export default function Page() {
+export default async function Page() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
   return (
     <div>
-      <NewPlanModal />
+      <NewPlanModal isGuest={session?.user.id !== null} />
     </div>
   );
 }

--- a/apps/searchneu/components/graduate/HeaderClient.tsx
+++ b/apps/searchneu/components/graduate/HeaderClient.tsx
@@ -19,9 +19,14 @@ import { deletePlanAction } from "@/lib/graduate/actions";
 interface HeaderClientProps {
   plans: AuditPlanSummary[];
   currentPlan: HydratedAuditPlan;
+  isGuest: boolean;
 }
 
-export function HeaderClient({ plans, currentPlan }: HeaderClientProps) {
+export function HeaderClient({
+  plans,
+  currentPlan,
+  isGuest,
+}: HeaderClientProps) {
   const router = useRouter();
   const [showNewPlan, setShowNewPlan] = useState(false);
 
@@ -168,7 +173,7 @@ export function HeaderClient({ plans, currentPlan }: HeaderClientProps) {
           </div>
         </div>
       </div>
-      <NewPlanModal open={showNewPlan} onOpenChange={setShowNewPlan} />
+      <NewPlanModal open={showNewPlan} onOpenChange={setShowNewPlan} isGuest />
     </div>
   );
 }

--- a/apps/searchneu/components/graduate/modal/NewPlanModal.tsx
+++ b/apps/searchneu/components/graduate/modal/NewPlanModal.tsx
@@ -44,16 +44,20 @@ import {
 } from "@/lib/graduate/auditPlanUtils";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+import { useLocalStorage } from "@/lib/graduate/useLocalStorage";
+import { CreateAuditPlanInput } from "@/lib/graduate/api-dtos";
 
 interface NewPlanModalProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  isGuest: boolean;
 }
 
 export default function NewPlanModal({
   open: controlledOpen,
   onOpenChange,
-}: NewPlanModalProps = {}) {
+  isGuest,
+}: NewPlanModalProps) {
   const router = useRouter();
   const [uncontrolledOpen, setUncontrolledOpen] = useState(true);
   const isControlled = controlledOpen !== undefined;
@@ -65,6 +69,7 @@ export default function NewPlanModal({
   const [isNoMajorSelected, setIsNoMajorSelected] = useState(false);
   const [isNoMinorSelected, setIsNoMinorSelected] = useState(false);
   const [catalogYear, setCatalogYear] = useState(-1);
+  //const { data: session } = authClient.useSession();
 
   //majors
   const { data: supportedMajorsData, error: majorsError } =
@@ -95,6 +100,12 @@ export default function NewPlanModal({
     { value: string; label: string }[]
   >([]);
   const [isLoadingConcentration, setIsLoadingConcentration] = useState(false);
+
+  // guest plan
+  const [, setGuestPlan] = useLocalStorage<CreateAuditPlanInput | null>(
+    "guest-plan",
+    null,
+  );
 
   //templates
   const recommendedTemplateLabel = `This will pre-populate your plan with the recommended course sequence`;
@@ -258,6 +269,12 @@ export default function NewPlanModal({
           ? undefined
           : concentration || undefined,
       };
+
+      if (isGuest) {
+        setGuestPlan(newPlan);
+        toast(`Plan ${newPlan.name} created locally! Redirecting...`);
+        return;
+      }
 
       const response = await fetch("/api/audit/plan", {
         method: "POST",

--- a/apps/searchneu/lib/graduate/useLocalStorage.ts
+++ b/apps/searchneu/lib/graduate/useLocalStorage.ts
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { toast } from "sonner";
+
+/**
+ * Using this hook allows for any component to access localstorage as NextJS
+ * uses SSR, so localstorage may not be accessible upon initial page load.
+ * Accessing the hook allows for the functionality of setting and getting a
+ * value in localstorage. The storedValue returned is the value in localstorage
+ * for the key given to this hook. If it is undefined, the hook will return null.
+ *
+ * @param key Key for the localstorage value.
+ */
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+): [T, (value: T) => void] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === "undefined") return defaultValue;
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : defaultValue;
+    } catch (error) {
+      console.error(error);
+      return defaultValue;
+    }
+  });
+
+  const setValue = (value: T) => {
+    try {
+      setStoredValue(value);
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      toast(`${error}`);
+    }
+  };
+
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
# Pull Request

This PR creates a 'guest-plan' in local storage to store a single plan for someone who is not signed into Search. When creating a new plan, the guest-plan will be updated with the most recent plan. This is done using useLocalStorage that has been migrated from the Graduate codebase and updating the handleCreatePlan of the newPlanModal. It does not cover updating the plan as edits are made.


dennis todo : need to integrate /guest page to display the plan from localstorage later in future ticket

Closes PR #294 

## Type of Change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a PCP (ie changes in deps, database, infrastructure, or package exports)

## Testing

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] To test first sign out if you are logged in to Search. Pull up 'Storage' in dev tools and view 'LocalStorage'. Create a new plan and see it show up under 'guest-plan' after clicking Create. If you create a new plan that new plan will replace the previous one (we only want a guest to be able to have 1 plan). 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] I have run a build for the entire monorepo
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commits are atomic and my branch is cleaned (no WIP commits)
