### PR TITLE
graduate audit page header (#323) TODO: link edit plan w/ shireen's t…

### DIFF
--- a/apps/searchneu/app/graduate/[planId]/page.tsx
+++ b/apps/searchneu/app/graduate/[planId]/page.tsx
@@ -137,8 +137,8 @@ export default async function PlanPage({
   const hydrated = await hydratePlan(plan);
 
   return (
-    <div>
-      <HeaderClient plans={userPlans} />
+    <div className="mx-auto flex flex-col gap-4 px-6">
+      <HeaderClient plans={userPlans} currentPlan={hydrated} />
       <PlanClient plan={hydrated} courseNames={hydrated.courseNames} />
     </div>
   );

--- a/apps/searchneu/components/graduate/HeaderClient.tsx
+++ b/apps/searchneu/components/graduate/HeaderClient.tsx
@@ -1,19 +1,174 @@
 "use client";
-import { AuditPlanSummary } from "@/lib/graduate/types";
-import Link from "next/link";
 
-export function HeaderClient({ plans }: { plans: AuditPlanSummary[] }) {
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { AuditPlanSummary, HydratedAuditPlan } from "@/lib/graduate/types";
+import NewPlanModal from "@/components/graduate/modal/NewPlanModal";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { PencilIcon, Trash2Icon, CopyIcon, ShareIcon } from "lucide-react";
+import { deletePlanAction } from "@/lib/graduate/actions";
+
+interface HeaderClientProps {
+  plans: AuditPlanSummary[];
+  currentPlan: HydratedAuditPlan;
+}
+
+export function HeaderClient({ plans, currentPlan }: HeaderClientProps) {
+  const router = useRouter();
+  const [showNewPlan, setShowNewPlan] = useState(false);
+
+  async function handleDelete() {
+    if (!confirm(`Delete "${currentPlan.name}"?`)) {
+      return;
+    }
+
+    const result = await deletePlanAction(currentPlan.id);
+
+    if (result.ok) {
+      toast(`Plan "${currentPlan.name}" deleted`);
+      const remaining = plans.filter((p) => p.id !== currentPlan.id);
+      if (remaining.length > 0) {
+        router.push(`/graduate/${remaining[0].id}`);
+      } else {
+        router.push("/graduate");
+      }
+    } else {
+      toast.error(result.msg ?? "Failed to delete plan");
+    }
+  }
+
+  function handleEdit() {
+    toast("Edit plan coming soon");
+  }
+
+  function handleCopy() {
+    toast("Copy plan coming soon");
+  }
+
+  function handleShare() {
+    toast("Share plan coming soon");
+  }
+
   return (
-    <div className="bg-neu1 mx-auto flex h-24 gap-2 overflow-scroll">
-      <ul>
-        {plans.map((plan) => {
-          return (
-            <li key={plan.id}>
-              <Link href={`/graduate/${plan.id}`}>{plan.name}</Link>
-            </li>
-          );
-        })}
-      </ul>
+    <div className="border-neu25 bg-neu1 mt-3 rounded-lg border p-6">
+      <div className="flex items-start gap-5">
+        <div className="flex flex-col gap-4">
+          <Select
+            value={String(currentPlan.id)}
+            onValueChange={(id) => router.push(`/graduate/${id}`)}
+          >
+            <SelectTrigger className="w-full min-w-48">
+              <SelectValue placeholder="Select a plan" />
+            </SelectTrigger>
+            <SelectContent>
+              {plans.map((plan) => (
+                <SelectItem key={plan.id} value={String(plan.id)}>
+                  {plan.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div className="flex items-center gap-1.5">
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowNewPlan(true)}
+              className="rounded-2xl"
+            >
+              + New Plan
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="size-8 rounded-full p-0"
+              onClick={handleEdit}
+              title="Edit plan"
+            >
+              <PencilIcon className="size-3.5" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="size-8 rounded-full p-0"
+              onClick={handleDelete}
+              title="Delete plan"
+            >
+              <Trash2Icon className="size-3.5" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="size-8 rounded-full p-0"
+              onClick={handleCopy}
+              title="Copy plan"
+            >
+              <CopyIcon className="size-3.5" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="size-8 rounded-full p-0"
+              onClick={handleShare}
+              title="Share plan"
+            >
+              <ShareIcon className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="border-neu4 self-stretch border-l" />
+
+        <div className="grid flex-1 grid-cols-[2fr_1fr]">
+          <div className="flex flex-col gap-1">
+            <span className="text-neu6 text-xs font-bold uppercase">
+              Majors
+            </span>
+            {currentPlan.majors.length > 0 ? (
+              currentPlan.majors.map((major) => (
+                <div key={major.name} className="flex items-baseline gap-2">
+                  <span className="text-neu7 text-lg leading-normal font-semibold">
+                    {major.name}
+                  </span>
+                  {currentPlan.concentration && (
+                    <span className="text-neu6 text-sm leading-normal font-normal italic">
+                      {currentPlan.concentration}
+                    </span>
+                  )}
+                </div>
+              ))
+            ) : (
+              <span className="text-neu6 text-sm">None</span>
+            )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-neu6 text-xs font-bold uppercase">
+              Minors
+            </span>
+            {currentPlan.minors.length > 0 ? (
+              currentPlan.minors.map((minor) => (
+                <span
+                  key={minor.name}
+                  className="text-neu7 text-lg leading-normal font-semibold"
+                >
+                  {minor.name}
+                </span>
+              ))
+            ) : (
+              <span className="text-neu6 text-sm">None</span>
+            )}
+          </div>
+        </div>
+      </div>
+      <NewPlanModal open={showNewPlan} onOpenChange={setShowNewPlan} />
     </div>
   );
 }

--- a/apps/searchneu/components/graduate/PlanClient.tsx
+++ b/apps/searchneu/components/graduate/PlanClient.tsx
@@ -283,7 +283,7 @@ export function PlanClient({ plan, courseNames }: PlanClientProps) {
               <Sidebar {...plan} />
             </div>
 
-            <div className="flex-grow overflow-auto p-4">
+            <div className="flex-grow overflow-auto pl-2">
               <div className="flex flex-col gap-0.5">
                 {schedule.years.map((year) => (
                   <AuditYearRow

--- a/apps/searchneu/components/graduate/modal/NewPlanModal.tsx
+++ b/apps/searchneu/components/graduate/modal/NewPlanModal.tsx
@@ -13,7 +13,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -46,9 +45,22 @@ import {
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
-export default function NewPlanModal() {
+interface NewPlanModalProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export default function NewPlanModal({
+  open: controlledOpen,
+  onOpenChange,
+}: NewPlanModalProps = {}) {
   const router = useRouter();
-  const [isOpen, setIsOpen] = useState(true);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(true);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
+  const setIsOpen = isControlled
+    ? (v: boolean) => onOpenChange?.(v)
+    : setUncontrolledOpen;
   const [message, setMessage] = useState("");
   const [isNoMajorSelected, setIsNoMajorSelected] = useState(false);
   const [isNoMinorSelected, setIsNoMinorSelected] = useState(false);
@@ -281,17 +293,16 @@ export default function NewPlanModal() {
 
   return (
     <>
-      <Button
-        className="bg-accent hover:bg-accent/80 w-full"
-        onClick={() => setIsOpen(true)}
-      >
-        open sesame{" "}
-      </Button>
+      {!isControlled && (
+        <Button
+          className="bg-accent hover:bg-accent/80 w-full"
+          onClick={() => setIsOpen(true)}
+        >
+          open sesame{" "}
+        </Button>
+      )}
       {isOpen && (
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
-          <DialogTrigger asChild>
-            <button className="hidden" />
-          </DialogTrigger>
           <DialogContent
             className="max-w-2xl"
             aria-label="New Plan Modal content"

--- a/apps/searchneu/lib/graduate/actions.ts
+++ b/apps/searchneu/lib/graduate/actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth/auth";
+import { deleteAuditPlan } from "@/lib/dal/audits";
+
+type ActionResult = { ok: true } | { ok: false; msg: string };
+
+export async function deletePlanAction(planId: number): Promise<ActionResult> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return { ok: false, msg: "No valid session" };
+  }
+
+  const result = await deleteAuditPlan(planId, session.user.id);
+
+  if (!result) {
+    return { ok: false, msg: "Plan not found or not authorized" };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
# 349
Adding header for the audit page on graduate

<img width="3022" height="1798" alt="image" src="https://github.com/user-attachments/assets/548b7279-f433-460c-8c42-6e7968f96543" />

Copy plan, share plan, and edit plan buttons are placeholders for now. Edit plan can be easily synced once edit plan modal ticket goes through. Will probably just add that to a different miscellaneous ticket.

Added actions.ts file to utilize DAL methods for delete button and future client component --> database interactions (seems to be the pattern search & plan are using)

Small changes to new plan modal to allow it to dynamically appear on different pages
<img width="1911" height="979" alt="Screenshot 2026-03-18 at 11 03 49 PM" src="https://github.com/user-attachments/assets/8615bc7a-907c-4f69-bdde-a8eb0bce4e61" />

Small styling changes elsewhere that will likely be changed in future


Major TODO: Flexible concentrations we will probably need a schema change for concentrations. The current data model is a string on plan but we probably need concentrations to be something like --> concentrations: Record<string, string> where the major maps to a concentration. Idt should be too ridiculous. 
