### PR TITLE
feat: add seat threshold detection (2 remaining, 1 remaining)

### DIFF
--- a/packages/scraper/src/update/main.ts
+++ b/packages/scraper/src/update/main.ts
@@ -12,6 +12,8 @@ import * as z from "zod";
 
 export interface UpdateTermResult {
   sectionsWithNewSeats: z.infer<typeof BannerSection>[];
+  sectionsWithTwoSeatsRemaining: z.infer<typeof BannerSection>[];
+  sectionsWithOneSeatRemaining: z.infer<typeof BannerSection>[];
   sectionsWithUpdatedSeats: z.infer<typeof BannerSection>[];
   sectionsWithNewWaitlistSeats: z.infer<typeof BannerSection>[];
   sectionsWithUpdatedWaitlistSeats: z.infer<typeof BannerSection>[];
@@ -79,6 +81,8 @@ export async function updateTerm(
     .where(eq(termsT.term, term));
 
   const sectionsWithNewSeats: z.infer<typeof BannerSection>[] = [];
+  const sectionsWithTwoSeatsRemaining: z.infer<typeof BannerSection>[] = [];
+  const sectionsWithOneSeatRemaining: z.infer<typeof BannerSection>[] = [];
   const sectionsWithUpdatedSeats: z.infer<typeof BannerSection>[] = [];
   const sectionsWithNewWaitlistSeats: z.infer<typeof BannerSection>[] = [];
   const sectionsWithUpdatedWaitlistSeats: z.infer<typeof BannerSection>[] = [];
@@ -100,6 +104,16 @@ export async function updateTerm(
 
     if (scrape.seatsAvailable > 0 && stale.seatRemaining === 0) {
       sectionsWithNewSeats.push(scrape);
+    }
+
+    // Seats dropped to exactly 2 (was previously > 2)
+    if (scrape.seatsAvailable === 2 && stale.seatRemaining > 2) {
+      sectionsWithTwoSeatsRemaining.push(scrape);
+    }
+
+    // Seats dropped to exactly 1 (was previously > 1)
+    if (scrape.seatsAvailable === 1 && stale.seatRemaining > 1) {
+      sectionsWithOneSeatRemaining.push(scrape);
     }
 
     if (scrape.waitAvailable > 0 && stale.waitRemaining === 0) {
@@ -189,10 +203,20 @@ export async function updateTerm(
     },
     "Sections with open waitlist spots",
   );
+  log.info(
+    { sections: sectionsWithTwoSeatsRemaining.map((s) => s.courseReferenceNumber) },
+    "Sections with 2 seats remaining",
+  );
+  log.info(
+    { sections: sectionsWithOneSeatRemaining.map((s) => s.courseReferenceNumber) },
+    "Sections with 1 seat remaining",
+  );
   log.info({ sections: newSections.map((s) => s.crn) }, "New sections");
 
   return {
     sectionsWithNewSeats,
+    sectionsWithTwoSeatsRemaining,
+    sectionsWithOneSeatRemaining,
     sectionsWithUpdatedSeats,
     sectionsWithNewWaitlistSeats,
     sectionsWithUpdatedWaitlistSeats,


### PR DESCRIPTION
## Summary
- Extends `updateTerm()` in the scraper to detect when sections drop to exactly 2 or 1 seats remaining
- Adds `sectionsWithTwoSeatsRemaining` and `sectionsWithOneSeatRemaining` to `UpdateTermResult`
- Backwards compatible — existing consumers get new fields they can optionally use

## Test plan
- [ ] Verify `pnpm build` succeeds (type-check)
- [ ] Confirm threshold logic: 2-remaining fires when `stale > 2 && scrape === 2`
- [ ] Confirm threshold logic: 1-remaining fires when `stale > 1 && scrape === 1`
- [ ] Confirm edge case: seats jumping from 3→1 only fires 1-remaining (not 2-remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)