### PR TITLE
feat: create @sneu/notifications package

### DIFF
--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@sneu/notifications",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "eslint .",
+    "test": "node --test --import tsx ./**/*.test.ts"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./providers/sms": {
+      "types": "./dist/providers/sms.d.ts",
+      "default": "./dist/providers/sms.js"
+    }
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.45.1"
+  },
+  "devDependencies": {
+    "@sneu/db": "workspace:*",
+    "@sneu/eslint-config": "workspace:*",
+    "@sneu/tsconfig": "workspace:*",
+    "@types/node": "^25.5.0",
+    "eslint": "^9.39.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+  Logger,
+  Notif,
+  NotificationProvider,
+  NotificationType,
+  TypedNotif,
+} from "./types";
+export { sendNotifications } from "./sender";
+export { renderMessage } from "./templates";

--- a/packages/notifications/src/providers/sms.ts
+++ b/packages/notifications/src/providers/sms.ts
@@ -1,0 +1,33 @@
+import type { NotificationProvider } from "../types";
+
+export interface TwilioSMSProviderOptions {
+  client: {
+    messages: {
+      create: (opts: {
+        body: string;
+        from: string;
+        to: string;
+      }) => Promise<unknown>;
+    };
+  };
+  fromNumber: string;
+}
+
+export class TwilioSMSProvider implements NotificationProvider {
+  readonly method = "SMS";
+  private client: TwilioSMSProviderOptions["client"];
+  private fromNumber: string;
+
+  constructor(opts: TwilioSMSProviderOptions) {
+    this.client = opts.client;
+    this.fromNumber = opts.fromNumber;
+  }
+
+  async send(to: string, message: string): Promise<void> {
+    await this.client.messages.create({
+      body: message,
+      from: this.fromNumber,
+      to,
+    });
+  }
+}

--- a/packages/notifications/src/sender.test.ts
+++ b/packages/notifications/src/sender.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { sendNotifications } from "./sender";
+import type { Notif, NotificationProvider, TypedNotif } from "./types";
+
+function makeNotif(overrides: Partial<Notif> = {}): Notif {
+  return {
+    id: 1,
+    term: "202510",
+    sectionCrn: "12345",
+    uid: "user-1",
+    method: "SMS",
+    count: 0,
+    limit: 3,
+    courseSubject: "CS",
+    courseNumber: "3500",
+    phoneNumber: "+11234567890",
+    phoneNumberVerified: true,
+    ...overrides,
+  };
+}
+
+function makeProvider(): NotificationProvider & { calls: { to: string; message: string }[] } {
+  const calls: { to: string; message: string }[] = [];
+  return {
+    method: "SMS",
+    calls,
+    async send(to: string, message: string) {
+      calls.push({ to, message });
+    },
+  };
+}
+
+function makeDb() {
+  const ops: { type: string; args: any[] }[] = [];
+
+  const chainable = (type: string) => {
+    const chain: any = {
+      set(...args: any[]) {
+        ops.push({ type: `${type}.set`, args });
+        return chain;
+      },
+      where(...args: any[]) {
+        ops.push({ type: `${type}.where`, args });
+        return chain;
+      },
+      values(...args: any[]) {
+        ops.push({ type: `${type}.values`, args });
+        return chain;
+      },
+      catch(fn: any) {
+        return chain;
+      },
+      then(resolve: any) {
+        resolve?.();
+        return chain;
+      },
+    };
+    return chain;
+  };
+
+  return {
+    ops,
+    update(_table: any) {
+      ops.push({ type: "update", args: [_table] });
+      return chainable("update");
+    },
+    insert(_table: any) {
+      ops.push({ type: "insert", args: [_table] });
+      return chainable("insert");
+    },
+  };
+}
+
+function silentLogger() {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+describe("sendNotifications", () => {
+  test("skips when no phone number", async () => {
+    const provider = makeProvider();
+    const db = makeDb();
+    const notifications: TypedNotif[] = [
+      { notif: makeNotif({ phoneNumber: null }), type: "seats_opened" },
+    ];
+
+    await sendNotifications(notifications, db, provider, silentLogger());
+    assert.strictEqual(provider.calls.length, 0);
+  });
+
+  test("skips when not verified", async () => {
+    const provider = makeProvider();
+    const db = makeDb();
+    const notifications: TypedNotif[] = [
+      {
+        notif: makeNotif({ phoneNumberVerified: false }),
+        type: "seats_opened",
+      },
+    ];
+
+    await sendNotifications(notifications, db, provider, silentLogger());
+    assert.strictEqual(provider.calls.length, 0);
+  });
+
+  test("soft-deletes when count >= limit", async () => {
+    const provider = makeProvider();
+    const db = makeDb();
+    const notifications: TypedNotif[] = [
+      {
+        notif: makeNotif({ count: 3, limit: 3 }),
+        type: "seats_opened",
+      },
+    ];
+
+    await sendNotifications(notifications, db, provider, silentLogger());
+    assert.strictEqual(provider.calls.length, 0);
+    assert.ok(db.ops.some((op) => op.type === "update"));
+  });
+
+  test("calls provider.send with correct message", async () => {
+    const provider = makeProvider();
+    const db = makeDb();
+    const notif = makeNotif();
+    const notifications: TypedNotif[] = [
+      { notif, type: "seats_opened" },
+    ];
+
+    await sendNotifications(notifications, db, provider, silentLogger());
+    assert.strictEqual(provider.calls.length, 1);
+    assert.strictEqual(provider.calls[0].to, "+11234567890");
+    assert.ok(provider.calls[0].message.includes("A seat opened up in CS 3500"));
+  });
+
+  test("handles error code 21610 (unsubscribe)", async () => {
+    const provider: NotificationProvider = {
+      method: "SMS",
+      async send() {
+        const err: any = new Error("Unsubscribed");
+        err.code = 21610;
+        throw err;
+      },
+    };
+    const db = makeDb();
+    const notifications: TypedNotif[] = [
+      { notif: makeNotif(), type: "seats_opened" },
+    ];
+
+    await sendNotifications(notifications, db, provider, silentLogger());
+    // Should have called update to soft-delete all user's trackers
+    const updateOps = db.ops.filter((op) => op.type === "update");
+    assert.ok(updateOps.length > 0);
+  });
+});

--- a/packages/notifications/src/sender.ts
+++ b/packages/notifications/src/sender.ts
@@ -1,0 +1,78 @@
+import { notificationsT, trackersT } from "@sneu/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { renderMessage } from "./templates";
+import type { Logger, NotificationProvider, TypedNotif } from "./types";
+
+const defaultLogger: Logger = {
+  info: (msg) => console.log(msg),
+  warn: (msg) => console.warn(msg),
+  error: (msg, err) => console.error(msg, err),
+};
+
+export async function sendNotifications(
+  notifications: TypedNotif[],
+  db: any,
+  provider: NotificationProvider,
+  logger: Logger = defaultLogger,
+): Promise<void> {
+  for (const { notif, type } of notifications) {
+    if (!notif.phoneNumber || !notif.phoneNumberVerified) {
+      continue;
+    }
+
+    if (notif.count >= notif.limit) {
+      await db
+        .update(trackersT)
+        .set({ deletedAt: new Date() })
+        .where(eq(trackersT.id, notif.id));
+      continue;
+    }
+
+    const message = renderMessage(type, notif);
+
+    try {
+      await provider.send(notif.phoneNumber, message);
+
+      logger.info(`Sent notification to ${notif.phoneNumber}`);
+
+      await db
+        .insert(notificationsT)
+        .values({
+          userId: notif.uid,
+          trackerId: notif.id,
+          method: provider.method,
+          message,
+        })
+        .catch((err: unknown) =>
+          logger.error("failed to log notification", err),
+        );
+
+      await db
+        .update(trackersT)
+        .set({
+          messageCount: sql`${trackersT.messageCount} + 1`,
+          deletedAt: notif.count + 1 >= notif.limit ? new Date() : null,
+        })
+        .where(eq(trackersT.id, notif.id))
+        .catch((err: unknown) =>
+          logger.error("failed to update message count", err),
+        );
+    } catch (err: any) {
+      if (err.code === 21610) {
+        logger.warn(
+          `${notif.phoneNumber} has unsubscribed from notifications`,
+        );
+
+        await db
+          .update(trackersT)
+          .set({ deletedAt: new Date() })
+          .where(eq(trackersT.userId, notif.uid));
+      } else {
+        logger.error(
+          `Error trying to send notification to ${notif.phoneNumber}`,
+          err,
+        );
+      }
+    }
+  }
+}

--- a/packages/notifications/src/templates.test.ts
+++ b/packages/notifications/src/templates.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { renderMessage } from "./templates";
+import type { Notif } from "./types";
+
+const notif: Notif = {
+  id: 1,
+  term: "202510",
+  sectionCrn: "12345",
+  uid: "user-1",
+  method: "SMS",
+  count: 0,
+  limit: 3,
+  courseSubject: "CS",
+  courseNumber: "3500",
+  phoneNumber: "+11234567890",
+  phoneNumberVerified: true,
+};
+
+describe("renderMessage", () => {
+  test("seats_opened", () => {
+    const msg = renderMessage("seats_opened", notif);
+    assert.strictEqual(
+      msg,
+      "A seat opened up in CS 3500 (CRN: 12345). Check it out at https://searchneu.com/catalog/202510/CS%203500 !",
+    );
+  });
+
+  test("seats_two_remaining", () => {
+    const msg = renderMessage("seats_two_remaining", notif);
+    assert.strictEqual(
+      msg,
+      "Only 2 seats remaining in CS 3500 (CRN: 12345). Check it out at https://searchneu.com/catalog/202510/CS%203500 !",
+    );
+  });
+
+  test("seats_one_remaining", () => {
+    const msg = renderMessage("seats_one_remaining", notif);
+    assert.strictEqual(
+      msg,
+      "Only 1 seat remaining in CS 3500 (CRN: 12345). Check it out at https://searchneu.com/catalog/202510/CS%203500 !",
+    );
+  });
+
+  test("waitlist_opened", () => {
+    const msg = renderMessage("waitlist_opened", notif);
+    assert.strictEqual(
+      msg,
+      "A waitlist seat has opened up in CS 3500 (CRN: 12345). Check it out at https://searchneu.com/catalog/202510/CS%203500 !",
+    );
+  });
+});

--- a/packages/notifications/src/templates.ts
+++ b/packages/notifications/src/templates.ts
@@ -1,0 +1,24 @@
+import type { Notif, NotificationType } from "./types";
+
+function courseUrl(n: Notif): string {
+  return `https://searchneu.com/catalog/${n.term}/${n.courseSubject}%20${n.courseNumber}`;
+}
+
+function courseLabel(n: Notif): string {
+  return `${n.courseSubject} ${n.courseNumber} (CRN: ${n.sectionCrn})`;
+}
+
+const templates: Record<NotificationType, (n: Notif) => string> = {
+  seats_opened: (n) =>
+    `A seat opened up in ${courseLabel(n)}. Check it out at ${courseUrl(n)} !`,
+  seats_two_remaining: (n) =>
+    `Only 2 seats remaining in ${courseLabel(n)}. Check it out at ${courseUrl(n)} !`,
+  seats_one_remaining: (n) =>
+    `Only 1 seat remaining in ${courseLabel(n)}. Check it out at ${courseUrl(n)} !`,
+  waitlist_opened: (n) =>
+    `A waitlist seat has opened up in ${courseLabel(n)}. Check it out at ${courseUrl(n)} !`,
+};
+
+export function renderMessage(type: NotificationType, notif: Notif): string {
+  return templates[type](notif);
+}

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -1,0 +1,35 @@
+export type NotificationType =
+  | "seats_opened" // was 0, now > 0
+  | "seats_two_remaining" // was > 2, now == 2
+  | "seats_one_remaining" // was > 1, now == 1
+  | "waitlist_opened"; // waitlist was 0, now > 0
+
+export interface Notif {
+  id: number;
+  term: string;
+  sectionCrn: string;
+  uid: string;
+  method: string;
+  count: number;
+  limit: number;
+  courseSubject: string;
+  courseNumber: string;
+  phoneNumber: string | null;
+  phoneNumberVerified: boolean | null;
+}
+
+export interface TypedNotif {
+  notif: Notif;
+  type: NotificationType;
+}
+
+export interface NotificationProvider {
+  send(to: string, message: string): Promise<void>;
+  readonly method: string;
+}
+
+export interface Logger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string, err?: unknown) => void;
+}

--- a/packages/notifications/tsconfig.json
+++ b/packages/notifications/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@sneu/tsconfig/base.json",
+  "compilerOptions": { "outDir": "dist" },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- New `@sneu/notifications` package with extensible `NotificationProvider` interface
- SMS provider (Twilio) with dependency injection (no hard Twilio dependency)
- Typed notification events: `seats_opened`, `seats_two_remaining`, `seats_one_remaining`, `waitlist_opened`
- Message templates and core `sendNotifications()` function
- Unit tests for templates and sender logic

## Test plan
- [ ] Verify `pnpm install && pnpm build` succeeds
- [ ] Run `cd packages/notifications && node --test --import tsx src/**/*.test.ts`
- [ ] Merge before PR #366 (scraper thresholds) and the route integration PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)