### PR TITLE
test: add Banner schema tests for scraper

### DIFF
--- a/packages/scraper/src/schemas/banner/campuses.test.ts
+++ b/packages/scraper/src/schemas/banner/campuses.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerCampuses, BannerCampusesResponse } from "./campuses";
+
+describe("BannerCampuses", () => {
+  test("accepts a valid campus with a 3-character code", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOS",
+      description: "Boston",
+    });
+    assert.ok(result.success);
+  });
+
+  test("rejects a code shorter than 3 characters", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BO",
+      description: "Boston",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects a code longer than 3 characters", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOST",
+      description: "Boston",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects missing description", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOS",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOS",
+      description: "Boston",
+      extra: "field",
+    });
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerCampusesResponse", () => {
+  test("accepts an array of valid campuses", () => {
+    const result = BannerCampusesResponse.safeParse([
+      { code: "BOS", description: "Boston" },
+      { code: "OAK", description: "Oakland" },
+    ]);
+    assert.ok(result.success);
+  });
+
+  test("accepts an empty array", () => {
+    const result = BannerCampusesResponse.safeParse([]);
+    assert.ok(result.success);
+  });
+
+  test("rejects if any campus in the array is invalid", () => {
+    const result = BannerCampusesResponse.safeParse([
+      { code: "BOS", description: "Boston" },
+      { code: "TOOLONG", description: "Invalid" },
+    ]);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/common.test.ts
+++ b/packages/scraper/src/schemas/banner/common.test.ts
@@ -1,0 +1,57 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerTerm, BannerCRN } from "./common";
+
+describe("BannerTerm", () => {
+  test("accepts a 6-character string", () => {
+    const result = BannerTerm.safeParse("202610");
+    assert.ok(result.success);
+  });
+
+  test("rejects a string shorter than 6 characters", () => {
+    const result = BannerTerm.safeParse("20261");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a string longer than 6 characters", () => {
+    const result = BannerTerm.safeParse("2026100");
+    assert.ok(!result.success);
+  });
+
+  test("rejects an empty string", () => {
+    const result = BannerTerm.safeParse("");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a non-string value", () => {
+    const result = BannerTerm.safeParse(202610);
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerCRN", () => {
+  test("accepts a 5-character string", () => {
+    const result = BannerCRN.safeParse("12345");
+    assert.ok(result.success);
+  });
+
+  test("rejects a string shorter than 5 characters", () => {
+    const result = BannerCRN.safeParse("1234");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a string longer than 5 characters", () => {
+    const result = BannerCRN.safeParse("123456");
+    assert.ok(!result.success);
+  });
+
+  test("rejects an empty string", () => {
+    const result = BannerCRN.safeParse("");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a non-string value", () => {
+    const result = BannerCRN.safeParse(12345);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/meetingsFaculty.test.ts
+++ b/packages/scraper/src/schemas/banner/meetingsFaculty.test.ts
@@ -1,0 +1,194 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BannerSectionMeetingsFaculty,
+  BannerSectionMeetingsFacultyResponse,
+} from "./meetingsFaculty";
+
+function validMeetingTime() {
+  return {
+    beginTime: "0935",
+    building: "RI",
+    buildingDescription: "Richards Hall",
+    campus: "BOS",
+    campusDescription: "Boston",
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingTime",
+    courseReferenceNumber: "12345",
+    creditHourSession: 4,
+    endDate: "04/13/2026",
+    endTime: "1015",
+    friday: false,
+    hoursWeek: 1.33,
+    meetingScheduleType: "LEC",
+    meetingType: "CLAS",
+    meetingTypeDescription: "Class",
+    monday: true,
+    room: "300",
+    saturday: false,
+    startDate: "01/12/2026",
+    sunday: false,
+    term: "202630",
+    thursday: false,
+    tuesday: false,
+    wednesday: true,
+  };
+}
+
+function validFacultyItem() {
+  return {
+    bannerId: "001234567",
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionFaculty",
+    courseReferenceNumber: "12345",
+    displayName: "Smith, John",
+    emailAddress: "j.smith@northeastern.edu",
+    primaryIndicator: true,
+    term: "202630",
+  };
+}
+
+function validMeetingsFaculty() {
+  return {
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingFaculty",
+    courseReferenceNumber: "12345",
+    faculty: [validFacultyItem()],
+    meetingTime: validMeetingTime(),
+    term: "202630",
+  };
+}
+
+describe("BannerSectionMeetingsFaculty", () => {
+  test("accepts a valid object with faculty and meetingTime", () => {
+    const result = BannerSectionMeetingsFaculty.safeParse(
+      validMeetingsFaculty(),
+    );
+    assert.ok(result.success);
+  });
+
+  test("accepts an empty faculty array", () => {
+    const data = validMeetingsFaculty();
+    data.faculty = [];
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable emailAddress in faculty", () => {
+    const data = validMeetingsFaculty();
+    data.faculty = [{ ...validFacultyItem(), emailAddress: null }];
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable beginTime and endTime", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = {
+      ...validMeetingTime(),
+      beginTime: null,
+      endTime: null,
+    };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable building and room", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = {
+      ...validMeetingTime(),
+      building: null,
+      buildingDescription: null,
+      room: null,
+    };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable campus fields", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = {
+      ...validMeetingTime(),
+      campus: null,
+      campusDescription: null,
+    };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable creditHourSession", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = { ...validMeetingTime(), creditHourSession: null };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("rejects invalid courseReferenceNumber (wrong length)", () => {
+    const data = validMeetingsFaculty();
+    data.courseReferenceNumber = "123";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects invalid term (wrong length)", () => {
+    const data = validMeetingsFaculty();
+    data.term = "20";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields on the top-level object (strictObject)", () => {
+    const data = { ...validMeetingsFaculty(), extra: "field" };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields on meetingTime (strictObject)", () => {
+    const data = validMeetingsFaculty();
+    (data.meetingTime as Record<string, unknown>).extra = "field";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields on faculty item (strictObject)", () => {
+    const data = validMeetingsFaculty();
+    data.faculty = [{ ...validFacultyItem(), extra: "field" } as never];
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates all day-of-week booleans in meetingTime", () => {
+    const data = validMeetingsFaculty();
+    (data.meetingTime as Record<string, unknown>).monday = "yes";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerSectionMeetingsFacultyResponse", () => {
+  test("accepts a valid response with fmt array", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({
+      fmt: [validMeetingsFaculty()],
+    });
+    assert.ok(result.success);
+  });
+
+  test("accepts a response with empty fmt array", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({
+      fmt: [],
+    });
+    assert.ok(result.success);
+  });
+
+  test("rejects missing fmt field", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({});
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({
+      fmt: [],
+      extra: "field",
+    });
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/section.test.ts
+++ b/packages/scraper/src/schemas/banner/section.test.ts
@@ -1,0 +1,332 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerSection, BannerSectionResponse } from "./section";
+
+function validMeetingTime() {
+  return {
+    beginTime: "0935",
+    building: "RI",
+    buildingDescription: "Richards Hall",
+    campus: "BOS",
+    campusDescription: "Boston",
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingTime",
+    courseReferenceNumber: "12345",
+    creditHourSession: 4,
+    endDate: "04/13/2026",
+    endTime: "1015",
+    friday: false,
+    hoursWeek: 1.33,
+    meetingScheduleType: "LEC",
+    meetingType: "CLAS",
+    meetingTypeDescription: "Class",
+    monday: true,
+    room: "300",
+    saturday: false,
+    startDate: "01/12/2026",
+    sunday: false,
+    term: "202630",
+    thursday: false,
+    tuesday: false,
+    wednesday: true,
+  };
+}
+
+function validMeetingsFacultyItem() {
+  return {
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingFaculty",
+    courseReferenceNumber: "12345",
+    faculty: [
+      {
+        bannerId: "001234567",
+        category: "01",
+        class: "net.hedtech.banner.student.schedule.SectionSessionFaculty",
+        courseReferenceNumber: "12345",
+        displayName: "Smith, John",
+        emailAddress: "j.smith@northeastern.edu",
+        primaryIndicator: true,
+        term: "202630",
+      },
+    ],
+    meetingTime: validMeetingTime(),
+    term: "202630",
+  };
+}
+
+function validSectionAttribute() {
+  return {
+    class: "net.hedtech.banner.student.schedule.SectionSessionAttribute",
+    code: "UBOS",
+    courseReferenceNumber: "12345",
+    description: "Boston",
+    isZTCAttribute: false,
+    termCode: "202630",
+  };
+}
+
+function validSection() {
+  return {
+    id: 1,
+    term: "202630",
+    termDesc: "Spring 2026 (View Only)",
+    courseReferenceNumber: "12345",
+    partOfTerm: "1",
+    courseNumber: "2500",
+    subject: "CS",
+    subjectDescription: "Computer Science",
+    sequenceNumber: "01",
+    campusDescription: "Boston",
+    scheduleTypeDescription: "Lecture",
+    courseTitle: "Fundamentals of Computer Science 1",
+    creditHours: null,
+    maximumEnrollment: 100,
+    enrollment: 95,
+    seatsAvailable: 5,
+    waitCapacity: 10,
+    waitCount: 3,
+    waitAvailable: 7,
+    crossList: null,
+    crossListCapacity: null,
+    crossListCount: null,
+    crossListAvailable: null,
+    creditHourHigh: null,
+    creditHourLow: 4,
+    creditHourIndicator: null,
+    openSection: true,
+    linkIdentifier: null,
+    isSectionLinked: false,
+    subjectCourse: "CS2500",
+    faculty: [],
+    meetingsFaculty: [validMeetingsFacultyItem()],
+    reservedSeatSummary: null,
+    sectionAttributes: [validSectionAttribute()],
+    instructionalMethod: null,
+    instructionalMethodDescription: null,
+  };
+}
+
+function validSectionResponse() {
+  return {
+    success: true,
+    totalCount: 1,
+    data: [validSection()],
+    pageOffset: 0,
+    pageMaxSize: 500,
+    sectionsFetchedCount: 1,
+    pathMode: null,
+    searchResultsConfigs: [
+      {
+        config: "config1",
+        display: "display1",
+        title: "Title",
+        required: true,
+        width: "100",
+      },
+    ],
+    ztcEncodedImage: "data:image/png;base64,...",
+  };
+}
+
+describe("BannerSection", () => {
+  test("accepts a valid section with all required fields", () => {
+    const result = BannerSection.safeParse(validSection());
+    assert.ok(result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const data = { ...validSection(), extra: "field" };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates nested meetingsFaculty array", () => {
+    const data = validSection();
+    data.meetingsFaculty = [{ invalid: true } as never];
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates nested sectionAttributes array", () => {
+    const data = validSection();
+    data.sectionAttributes = [{ invalid: true } as never];
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("courseNumber must be exactly 4 characters", () => {
+    const tooShort = { ...validSection(), courseNumber: "250" };
+    assert.ok(!BannerSection.safeParse(tooShort).success);
+
+    const tooLong = { ...validSection(), courseNumber: "25000" };
+    assert.ok(!BannerSection.safeParse(tooLong).success);
+
+    const exact = { ...validSection(), courseNumber: "2500" };
+    assert.ok(BannerSection.safeParse(exact).success);
+  });
+
+  test("courseReferenceNumber must be exactly 5 characters (BannerCRN)", () => {
+    const tooShort = { ...validSection(), courseReferenceNumber: "1234" };
+    assert.ok(!BannerSection.safeParse(tooShort).success);
+
+    const tooLong = { ...validSection(), courseReferenceNumber: "123456" };
+    assert.ok(!BannerSection.safeParse(tooLong).success);
+
+    const exact = { ...validSection(), courseReferenceNumber: "12345" };
+    assert.ok(BannerSection.safeParse(exact).success);
+  });
+
+  test("term must be exactly 6 characters (BannerTerm)", () => {
+    const tooShort = { ...validSection(), term: "20263" };
+    assert.ok(!BannerSection.safeParse(tooShort).success);
+
+    const tooLong = { ...validSection(), term: "2026300" };
+    assert.ok(!BannerSection.safeParse(tooLong).success);
+
+    const exact = { ...validSection(), term: "202630" };
+    assert.ok(BannerSection.safeParse(exact).success);
+  });
+
+  test("linkIdentifier must be null", () => {
+    const data = { ...validSection(), linkIdentifier: "A" };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("isSectionLinked must be false", () => {
+    const data = { ...validSection(), isSectionLinked: true };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("faculty must be an empty array (length 0)", () => {
+    const data = { ...validSection(), faculty: [null] };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("creditHours is nullable", () => {
+    const withNull = { ...validSection(), creditHours: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), creditHours: 4 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossList is nullable", () => {
+    const withNull = { ...validSection(), crossList: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossList: "XL01" };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossListCapacity is nullable", () => {
+    const withNull = { ...validSection(), crossListCapacity: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossListCapacity: 50 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossListCount is nullable", () => {
+    const withNull = { ...validSection(), crossListCount: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossListCount: 30 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossListAvailable is nullable", () => {
+    const withNull = { ...validSection(), crossListAvailable: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossListAvailable: 20 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("creditHourHigh is nullable", () => {
+    const withNull = { ...validSection(), creditHourHigh: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), creditHourHigh: 8 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("creditHourIndicator is nullable", () => {
+    const withNull = { ...validSection(), creditHourIndicator: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), creditHourIndicator: "OR" };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("instructionalMethod is nullable", () => {
+    const withNull = { ...validSection(), instructionalMethod: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = {
+      ...validSection(),
+      instructionalMethod: "Traditional",
+    };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("instructionalMethodDescription is nullable", () => {
+    const withNull = {
+      ...validSection(),
+      instructionalMethodDescription: null,
+    };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = {
+      ...validSection(),
+      instructionalMethodDescription: "In Person",
+    };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("reservedSeatSummary must be null", () => {
+    const withNull = { ...validSection(), reservedSeatSummary: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = {
+      ...validSection(),
+      reservedSeatSummary: "something",
+    };
+    assert.ok(!BannerSection.safeParse(withValue).success);
+  });
+});
+
+describe("BannerSectionResponse", () => {
+  test("accepts a valid response with data array", () => {
+    const result = BannerSectionResponse.safeParse(validSectionResponse());
+    assert.ok(result.success);
+  });
+
+  test("accepts a response with empty data array", () => {
+    const data = { ...validSectionResponse(), data: [], totalCount: 0, sectionsFetchedCount: 0 };
+    const result = BannerSectionResponse.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("rejects missing required fields", () => {
+    const result = BannerSectionResponse.safeParse({
+      success: true,
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const data = { ...validSectionResponse(), extra: "field" };
+    const result = BannerSectionResponse.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates searchResultsConfigs entries (strictObject)", () => {
+    const data = validSectionResponse();
+    data.searchResultsConfigs = [{ config: "c", extra: true } as never];
+    const result = BannerSectionResponse.safeParse(data);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/terms.test.ts
+++ b/packages/scraper/src/schemas/banner/terms.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerTerms, BannerTermsResponse } from "./terms";
+
+describe("BannerTerms", () => {
+  test("accepts a valid term with a 6-character code", () => {
+    const result = BannerTerms.safeParse({
+      code: "202610",
+      description: "Spring 2026",
+    });
+    assert.ok(result.success);
+  });
+
+  test("rejects a code shorter than 6 characters", () => {
+    const result = BannerTerms.safeParse({
+      code: "20261",
+      description: "Spring 2026",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects a code longer than 6 characters", () => {
+    const result = BannerTerms.safeParse({
+      code: "2026100",
+      description: "Spring 2026",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects missing description", () => {
+    const result = BannerTerms.safeParse({
+      code: "202610",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = BannerTerms.safeParse({
+      code: "202610",
+      description: "Spring 2026",
+      extra: "field",
+    });
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerTermsResponse", () => {
+  test("accepts an array of valid terms", () => {
+    const result = BannerTermsResponse.safeParse([
+      { code: "202610", description: "Spring 2026" },
+      { code: "202530", description: "Fall 2025" },
+    ]);
+    assert.ok(result.success);
+  });
+
+  test("accepts an empty array", () => {
+    const result = BannerTermsResponse.safeParse([]);
+    assert.ok(result.success);
+  });
+
+  test("rejects if any term in the array is invalid", () => {
+    const result = BannerTermsResponse.safeParse([
+      { code: "202610", description: "Spring 2026" },
+      { code: "BAD", description: "Invalid" },
+    ]);
+    assert.ok(!result.success);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for Banner API response schemas (common, section, meetingsFaculty, campuses, terms)
- 68 tests covering valid/invalid data, strictObject enforcement, nullable fields, length constraints

## Test plan
- [x] All 68 tests pass with `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)