### PR TITLE
test: add upload/update utility tests for scraper

### DIFF
--- a/packages/scraper/src/update/notifs.test.ts
+++ b/packages/scraper/src/update/notifs.test.ts
@@ -1,0 +1,204 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { sendNotifications, type Notif, type NotificationSender } from "./notifs";
+
+function makeNotif(overrides: Partial<Notif> = {}): Notif {
+  return {
+    id: 1,
+    term: "202510",
+    sectionCrn: "12345",
+    uid: "user1",
+    method: "SMS",
+    count: 0,
+    limit: 5,
+    courseSubject: "CS",
+    courseNumber: "2500",
+    phoneNumber: "+11234567890",
+    phoneNumberVerified: true,
+    ...overrides,
+  };
+}
+
+function makeSender(): NotificationSender & { calls: Array<{ to: string; message: string }> } {
+  const calls: Array<{ to: string; message: string }> = [];
+  return {
+    calls,
+    async sendSMS(to: string, message: string) {
+      calls.push({ to, message });
+    },
+  };
+}
+
+/** Creates a chainable mock db that records calls. */
+function makeMockDb() {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+
+  function chainable(): any {
+    const chain: any = {
+      set(...args: unknown[]) {
+        calls.push({ method: "set", args });
+        return chain;
+      },
+      where(...args: unknown[]) {
+        calls.push({ method: "where", args });
+        return Promise.resolve();
+      },
+      values(...args: unknown[]) {
+        calls.push({ method: "values", args });
+        return chain;
+      },
+      catch(fn: (err: Error) => void) {
+        return Promise.resolve().catch(fn);
+      },
+    };
+    return chain;
+  }
+
+  return {
+    calls,
+    update() {
+      calls.push({ method: "update", args: [] });
+      return chainable();
+    },
+    insert() {
+      calls.push({ method: "insert", args: [] });
+      return chainable();
+    },
+  };
+}
+
+function makeLogger() {
+  const logs: Array<{ level: string; msg: string }> = [];
+  return {
+    logs,
+    info(msg: string) {
+      logs.push({ level: "info", msg });
+    },
+    warn(msg: string) {
+      logs.push({ level: "warn", msg });
+    },
+    error(msg: string) {
+      logs.push({ level: "error", msg });
+    },
+  };
+}
+
+describe("sendNotifications", () => {
+  test("sends SMS for seat notifications with correct message format", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 1);
+    assert.equal(sender.calls[0].to, "+11234567890");
+    assert.ok(sender.calls[0].message.includes("A seat opened up in CS 2500"));
+    assert.ok(sender.calls[0].message.includes("CRN: 12345"));
+    assert.ok(
+      sender.calls[0].message.includes(
+        "https://searchneu.com/catalog/202510/CS%202500",
+      ),
+    );
+  });
+
+  test("sends SMS for waitlist notifications with different message format", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([], [notif], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 1);
+    assert.ok(
+      sender.calls[0].message.includes("A waitlist seat has opened up in CS 2500"),
+    );
+  });
+
+  test("skips notifications when phoneNumber is null", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif({ phoneNumber: null });
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 0);
+  });
+
+  test("skips notifications when phoneNumberVerified is false", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif({ phoneNumberVerified: false });
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 0);
+  });
+
+  test("when count >= limit, marks tracker as deleted without sending SMS", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif({ count: 5, limit: 5 });
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 0);
+    assert.ok(db.calls.some((c) => c.method === "update"));
+  });
+
+  test("on successful SMS: logs notification and updates tracker", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.ok(logger.logs.some((l) => l.level === "info" && l.msg.includes("+11234567890")));
+    // insert for notification log, update for message count
+    assert.ok(db.calls.some((c) => c.method === "insert"));
+    assert.ok(db.calls.some((c) => c.method === "update"));
+  });
+
+  test("on Twilio error 21610: deletes all trackers for that user", async () => {
+    const sender: NotificationSender = {
+      async sendSMS() {
+        const err = new Error("Unsubscribed") as Error & { code: number };
+        err.code = 21610;
+        throw err;
+      },
+    };
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.ok(logger.logs.some((l) => l.level === "warn" && l.msg.includes("unsubscribed")));
+    assert.ok(db.calls.some((c) => c.method === "update"));
+  });
+
+  test("on generic error: logs error message", async () => {
+    const sender: NotificationSender = {
+      async sendSMS() {
+        throw new Error("Something went wrong");
+      },
+    };
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.ok(
+      logger.logs.some(
+        (l) => l.level === "error" && l.msg.includes("+11234567890"),
+      ),
+    );
+  });
+});

--- a/packages/scraper/src/upload/main.test.ts
+++ b/packages/scraper/src/upload/main.test.ts
@@ -1,0 +1,175 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { filterScrapeByPartOfTerm } from "./main";
+
+function makeSection(overrides: Record<string, unknown> = {}) {
+  return {
+    crn: "10001",
+    name: "Test Section",
+    description: "A test section",
+    sectionNumber: "01",
+    partOfTerm: "1",
+    seatCapacity: 50,
+    seatRemaining: 10,
+    waitlistCapacity: 10,
+    waitlistRemaining: 5,
+    classType: "Lecture",
+    honors: false,
+    campus: "Boston",
+    meetingTimes: [],
+    faculty: [],
+    xlist: [],
+    coreqs: {},
+    prereqs: {},
+    ...overrides,
+  };
+}
+
+function makeScrape(
+  courses: Array<{
+    subject: string;
+    courseNumber: string;
+    name?: string;
+  }>,
+  sections: Record<string, Array<ReturnType<typeof makeSection>>>,
+) {
+  return {
+    version: 5 as const,
+    timestamp: "2025-01-01T00:00:00Z",
+    term: { code: "202510", description: "Spring 2025" },
+    courses: courses.map((c) => ({
+      subject: c.subject,
+      courseNumber: c.courseNumber,
+      specialTopics: false,
+      name: c.name ?? "Test Course",
+      description: "A test course",
+      maxCredits: 4,
+      minCredits: 4,
+      attributes: [],
+      coreqs: {},
+      prereqs: {},
+      postreqs: {},
+    })),
+    sections,
+    attributes: [],
+    subjects: [],
+    campuses: [],
+  };
+}
+
+describe("filterScrapeByPartOfTerm", () => {
+  test("filters sections by partOfTerm value", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "A" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.sections["CS2500"].length, 1);
+    assert.equal(result.sections["CS2500"][0].crn, "10001");
+  });
+
+  test("removes courses with no matching sections", () => {
+    const scrape = makeScrape(
+      [
+        { subject: "CS", courseNumber: "2500" },
+        { subject: "CS", courseNumber: "2510" },
+      ],
+      {
+        CS2500: [makeSection({ crn: "10001", partOfTerm: "A" })],
+        CS2510: [makeSection({ crn: "10002", partOfTerm: "B" })],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "A");
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.courses[0].subject, "CS");
+    assert.equal(result.courses[0].courseNumber, "2500");
+    assert.equal(result.sections["CS2510"], undefined);
+  });
+
+  test("keeps courses that have at least one matching section", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "A" }),
+          makeSection({ crn: "10003", partOfTerm: "1" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.sections["CS2500"].length, 2);
+  });
+
+  test("all sections match: returns equivalent scrape", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "1" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.sections["CS2500"].length, 2);
+  });
+
+  test("no sections match: returns empty courses and sections", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "A" }),
+          makeSection({ crn: "10002", partOfTerm: "B" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.courses.length, 0);
+    assert.deepStrictEqual(result.sections, {});
+  });
+
+  test("does not mutate the original scrape object", () => {
+    const scrape = makeScrape(
+      [
+        { subject: "CS", courseNumber: "2500" },
+        { subject: "CS", courseNumber: "2510" },
+      ],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "A" }),
+        ],
+        CS2510: [makeSection({ crn: "10003", partOfTerm: "A" })],
+      },
+    );
+
+    const originalCourseCount = scrape.courses.length;
+    const originalCS2500Count = scrape.sections["CS2500"].length;
+    const originalCS2510Count = scrape.sections["CS2510"].length;
+
+    filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(scrape.courses.length, originalCourseCount);
+    assert.equal(scrape.sections["CS2500"].length, originalCS2500Count);
+    assert.equal(scrape.sections["CS2510"].length, originalCS2510Count);
+  });
+});

--- a/packages/scraper/src/upload/main.ts
+++ b/packages/scraper/src/upload/main.ts
@@ -183,7 +183,7 @@ export async function uploadCatalogTerm(
  * Returns a filtered copy of the scrape with only sections matching the
  * given partOfTerm, and only courses that still have sections after filtering.
  */
-function filterScrapeByPartOfTerm(
+export function filterScrapeByPartOfTerm(
   scrape: z.infer<typeof ScraperBannerCache>,
   partOfTerm: string,
 ): z.infer<typeof ScraperBannerCache> {

--- a/packages/scraper/src/upload/types.test.ts
+++ b/packages/scraper/src/upload/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { chunk } from "./types";
+
+describe("chunk", () => {
+  test("empty array returns empty array", () => {
+    assert.deepStrictEqual(chunk([], 2), []);
+  });
+
+  test("array divides evenly", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3, 4], 2), [
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  test("array with remainder", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3, 4, 5], 2), [
+      [1, 2],
+      [3, 4],
+      [5],
+    ]);
+  });
+
+  test("single element array", () => {
+    assert.deepStrictEqual(chunk([42], 3), [[42]]);
+  });
+
+  test("size larger than array returns single chunk", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3], 10), [[1, 2, 3]]);
+  });
+
+  test("size of 1 returns array of single-element arrays", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3], 1), [[1], [2], [3]]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 20 unit tests for `chunk()`, `filterScrapeByPartOfTerm()`, and `sendNotifications()`
- Exports `filterScrapeByPartOfTerm` for testability
- Covers SMS notification logic, Twilio error handling, partOfTerm filtering

## Test plan
- [x] All 20 tests pass with `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)