### PR TITLE
test: add faculty, names, descriptions step tests for scraper

### DIFF
--- a/packages/scraper/src/generate/steps/courseDescriptions.test.ts
+++ b/packages/scraper/src/generate/steps/courseDescriptions.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeCourseDescriptions } from "./courseDescriptions";
+import { ScraperEventEmitter } from "../../events";
+
+const BASE_URL = "https://nubanner.neu.edu";
+const TERM = "202510";
+const POST_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/getCourseDescription";
+
+function makeFe() {
+  return new FetchEngine({
+    maxConcurrent: 1,
+    throttleDelay: 0,
+    initialRetryDelay: 10,
+    maxRetries: 0,
+  });
+}
+
+function makeItem(crn: string) {
+  return { crn, description: "" };
+}
+
+describe("scrapeCourseDescriptions", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("successfully extracts description and updates item in place", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Introduction to algorithms and data structures.");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(
+      item.description,
+      "Introduction to algorithms and data structures.",
+    );
+  });
+
+  test("removes HTML tags from description", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<p>This course covers <b>advanced</b> topics in <em>CS</em>.</p>",
+      );
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(
+      item.description,
+      "This course covers advanced topics in CS.",
+    );
+  });
+
+  test("removes HTML comments from description", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "Some text<!-- this is a comment --> and more text.",
+      );
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Some text and more text.");
+  });
+
+  test("handles double HTML-encoded entities", async () => {
+    const item = makeItem("12345");
+
+    // &amp;amp; -> first decode -> &amp; -> second decode -> &
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Algorithms &amp;amp; Data Structures");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Algorithms & Data Structures");
+  });
+
+  test("trims whitespace from description", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "   Some description with whitespace   ");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Some description with whitespace");
+  });
+
+  test("returns failed CRNs on fetch failure", async () => {
+    const item = makeItem("99999");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=99999`)
+      .replyWithError("connection refused");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, ["99999", "99999"]);
+    assert.equal(item.description, "");
+  });
+
+  test("emits fetch:error event on failure", async () => {
+    const item = makeItem("77777");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=77777`)
+      .replyWithError("timeout");
+
+    await scrapeCourseDescriptions(makeFe(), TERM, [item], emitter);
+
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0].crn, "77777");
+    assert.equal(errors[0].step, "description");
+    assert.ok(errors[0].message.includes("timeout"));
+  });
+
+  test("processes multiple items", async () => {
+    const item1 = makeItem("11111");
+    const item2 = makeItem("22222");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=11111`)
+      .reply(200, "First description.");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=22222`)
+      .reply(200, "Second description.");
+
+    const failed = await scrapeCourseDescriptions(
+      makeFe(),
+      TERM,
+      [item1, item2],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(item1.description, "First description.");
+    assert.equal(item2.description, "Second description.");
+  });
+
+  test("handles combined HTML tags, comments, and entities", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<!-- comment --><p>Study of &amp;amp; in <b>depth</b>.</p><!-- end -->",
+      );
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Study of & in depth.");
+  });
+});

--- a/packages/scraper/src/generate/steps/courseNames.test.ts
+++ b/packages/scraper/src/generate/steps/courseNames.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeCatalogDetails } from "./courseNames";
+import { ScraperEventEmitter } from "../../events";
+import type { Course } from "../../types";
+
+const BASE_URL = "https://nubanner.neu.edu";
+const TERM = "202510";
+const POST_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/getSectionCatalogDetails";
+
+function makeFe() {
+  return new FetchEngine({
+    maxConcurrent: 1,
+    throttleDelay: 0,
+    initialRetryDelay: 10,
+    maxRetries: 0,
+  });
+}
+
+function makeCourse(crn: string): Course & { crn: string } {
+  return {
+    subject: "CS",
+    courseNumber: "2500",
+    specialTopics: false,
+    name: "",
+    description: "",
+    maxCredits: 4,
+    minCredits: 4,
+    attributes: [],
+    coreqs: {},
+    prereqs: {},
+    postreqs: {},
+    crn,
+  };
+}
+
+describe("scrapeCatalogDetails", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("successfully extracts title from HTML response", async () => {
+    const course = makeCourse("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<br/>\nTitle:Fundamentals of Computer Science\n<br/>Some other info",
+      );
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Fundamentals of Computer Science");
+  });
+
+  test("strips HTML tags from response before extracting title", async () => {
+    const course = makeCourse("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<p><b>Title:</b><em>Algorithms &amp;amp; Data</em></p>",
+      );
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Algorithms & Data");
+  });
+
+  test("falls back to 'Unknown' when no Title: line is present", async () => {
+    const course = makeCourse("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Some random catalog text with no title line");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Unknown");
+  });
+
+  test("returns failed CRNs on fetch failure", async () => {
+    const course = makeCourse("99999");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=99999`)
+      .replyWithError("connection refused");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, ["99999", "99999"]);
+    assert.equal(course.name, "");
+  });
+
+  test("returns failed CRNs when fetch error causes undefined response", async () => {
+    const course = makeCourse("88888");
+
+    // A fetch error returns undefined, which fails z.string() parse
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=88888`)
+      .replyWithError("server error");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, ["88888", "88888"]);
+  });
+
+  test("emits fetch:error on failure", async () => {
+    const course = makeCourse("77777");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=77777`)
+      .replyWithError("timeout");
+
+    await scrapeCatalogDetails(makeFe(), TERM, [course], emitter);
+
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0].crn, "77777");
+    assert.equal(errors[0].step, "catalog-details");
+    assert.ok(errors[0].message.includes("timeout"));
+  });
+
+  test("handles double HTML-encoded entities", async () => {
+    const course = makeCourse("12345");
+
+    // &amp;amp; -> first decode -> &amp; -> second decode -> &
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Title:Algorithms &amp;amp; Data Structures");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Algorithms & Data Structures");
+  });
+
+  test("processes multiple courses", async () => {
+    const course1 = makeCourse("11111");
+    const course2 = makeCourse("22222");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=11111`)
+      .reply(200, "Title:Algorithms");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=22222`)
+      .reply(200, "Title:Networks");
+
+    const failed = await scrapeCatalogDetails(
+      makeFe(),
+      TERM,
+      [course1, course2],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(course1.name, "Algorithms");
+    assert.equal(course2.name, "Networks");
+  });
+});

--- a/packages/scraper/src/generate/steps/meetingsFaculty.test.ts
+++ b/packages/scraper/src/generate/steps/meetingsFaculty.test.ts
@@ -1,0 +1,295 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeMeetingsFaculty } from "./meetingsFaculty";
+import { ScraperEventEmitter } from "../../events";
+import type { Section } from "../../types";
+
+const BASE_URL = "https://nubanner.neu.edu";
+const TERM = "202510";
+
+function makeFe() {
+  return new FetchEngine({
+    maxConcurrent: 1,
+    throttleDelay: 0,
+    initialRetryDelay: 10,
+    maxRetries: 0,
+  });
+}
+
+function makeSection(crn: string): Section {
+  return {
+    crn,
+    name: "",
+    description: "",
+    sectionNumber: "01",
+    partOfTerm: "1",
+    seatCapacity: 30,
+    seatRemaining: 10,
+    waitlistCapacity: 0,
+    waitlistRemaining: 0,
+    classType: "Lecture",
+    honors: false,
+    campus: "BOS",
+    meetingTimes: [],
+    faculty: [],
+    xlist: [],
+    coreqs: {},
+    prereqs: {},
+  };
+}
+
+function makeFacultyResponse(
+  crn: string,
+  term: string,
+  faculty: {
+    displayName: string;
+    emailAddress: string | null;
+    primaryIndicator: boolean;
+    bannerId?: string;
+  }[],
+) {
+  return {
+    fmt: [
+      {
+        category: "01",
+        class: "net.hedtech.banner.general.overall.SectionMeetingTimeView",
+        courseReferenceNumber: crn,
+        faculty: faculty.map((f) => ({
+          bannerId: f.bannerId ?? "12345",
+          category: "01",
+          class:
+            "net.hedtech.banner.general.overall.SectionMeetingTimeFacultyView",
+          courseReferenceNumber: crn,
+          displayName: f.displayName,
+          emailAddress: f.emailAddress,
+          primaryIndicator: f.primaryIndicator,
+          term,
+        })),
+        meetingTime: {
+          beginTime: "0800",
+          building: "SN",
+          buildingDescription: "Snell Library",
+          campus: "BOS",
+          campusDescription: "Boston",
+          category: "01",
+          class:
+            "net.hedtech.banner.general.overall.SectionMeetingTimeView",
+          courseReferenceNumber: crn,
+          creditHourSession: 4,
+          endDate: "12/10/2025",
+          endTime: "0940",
+          friday: false,
+          hoursWeek: 2.66,
+          meetingScheduleType: "LEC",
+          meetingType: "CLAS",
+          meetingTypeDescription: "Class",
+          monday: true,
+          room: "108",
+          saturday: false,
+          startDate: "09/01/2025",
+          sunday: false,
+          term,
+          thursday: false,
+          tuesday: false,
+          wednesday: true,
+        },
+        term,
+      },
+    ],
+  };
+}
+
+describe("scrapeMeetingsFaculty", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("successfully extracts faculty and updates section in place", async () => {
+    const section = makeSection("12345");
+    const responseBody = makeFacultyResponse("12345", TERM, [
+      {
+        displayName: "John Smith",
+        emailAddress: "j.smith@northeastern.edu",
+        primaryIndicator: true,
+      },
+    ]);
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=12345`,
+      )
+      .reply(200, responseBody);
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(section.faculty.length, 1);
+    assert.equal(section.faculty[0].displayName, "John Smith");
+    assert.equal(section.faculty[0].email, "j.smith@northeastern.edu");
+    assert.equal(section.faculty[0].primary, true);
+  });
+
+  test("handles HTML entities in faculty names (double decode)", async () => {
+    const section = makeSection("12345");
+    // Double-encoded ampersand: &amp;amp; -> first decode -> &amp; -> second decode -> &
+    const responseBody = makeFacultyResponse("12345", TERM, [
+      {
+        displayName: "O&amp;amp;Brien",
+        emailAddress: null,
+        primaryIndicator: false,
+      },
+    ]);
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=12345`,
+      )
+      .reply(200, responseBody);
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(section.faculty[0].displayName, "O&Brien");
+    assert.equal(section.faculty[0].email, null);
+    assert.equal(section.faculty[0].primary, false);
+  });
+
+  test("returns failed CRNs array on fetch failure", async () => {
+    const section = makeSection("99999");
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=99999`,
+      )
+      .replyWithError("connection refused");
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, ["99999", "99999"]);
+    assert.deepEqual(section.faculty, []);
+  });
+
+  test("returns failed CRNs on parse failure", async () => {
+    const section = makeSection("88888");
+
+    // Return an object that does not match the expected schema (missing "fmt" key)
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=88888`,
+      )
+      .reply(200, { invalid: "data" });
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, ["88888"]);
+    assert.deepEqual(section.faculty, []);
+  });
+
+  test("emits fetch:error event on fetch failure", async () => {
+    const section = makeSection("77777");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=77777`,
+      )
+      .replyWithError("timeout");
+
+    await scrapeMeetingsFaculty(makeFe(), TERM, [section], emitter);
+
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0].crn, "77777");
+    assert.equal(errors[0].step, "faculty");
+    assert.ok(errors[0].message.includes("timeout"));
+  });
+
+  test("emits fetch:error event on parse failure", async () => {
+    const section = makeSection("66666");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=66666`,
+      )
+      .reply(200, { notFmt: [] });
+
+    await scrapeMeetingsFaculty(makeFe(), TERM, [section], emitter);
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].crn, "66666");
+    assert.equal(errors[0].step, "faculty");
+  });
+
+  test("processes multiple sections", async () => {
+    const section1 = makeSection("11111");
+    const section2 = makeSection("22222");
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=11111`,
+      )
+      .reply(
+        200,
+        makeFacultyResponse("11111", TERM, [
+          {
+            displayName: "Alice",
+            emailAddress: "alice@neu.edu",
+            primaryIndicator: true,
+          },
+        ]),
+      );
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=22222`,
+      )
+      .reply(
+        200,
+        makeFacultyResponse("22222", TERM, [
+          {
+            displayName: "Bob",
+            emailAddress: "bob@neu.edu",
+            primaryIndicator: false,
+          },
+        ]),
+      );
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section1, section2],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(section1.faculty[0].displayName, "Alice");
+    assert.equal(section2.faculty[0].displayName, "Bob");
+  });
+});


### PR DESCRIPTION
## Summary
- Add 24 unit tests for `scrapeMeetingsFaculty()`, `scrapeCatalogDetails()`, and `scrapeCourseDescriptions()`
- Uses nock + FetchEngine to test HTTP scraping, HTML entity decoding, in-place mutation

## Test plan
- [x] All 24 tests pass with `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)