### PR TITLE
test: add comprehensive tests for scraper package

### DIFF
--- a/packages/scraper/src/config.test.ts
+++ b/packages/scraper/src/config.test.ts
@@ -1,0 +1,75 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { TermConfig, ManifestConfig, PartOfTermConfig } from "./config.js";
+
+describe("TermConfig", () => {
+  test("valid: minimal with only required fields", () => {
+    const result = TermConfig.safeParse({ term: 202510, activeUntil: "2025-12-31" });
+    assert.equal(result.success, true);
+  });
+
+  test("valid: full object with all optional fields", () => {
+    const result = TermConfig.safeParse({
+      term: 202510,
+      name: "Fall 2025",
+      activeUntil: "2025-12-31",
+      splitByPartOfTerm: true,
+      parts: [{ code: "A", name: "Part A", activeUntil: "2025-10-15" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("invalid: missing term", () => {
+    const result = TermConfig.safeParse({ activeUntil: "2025-12-31" });
+    assert.equal(result.success, false);
+  });
+
+  test("invalid: missing activeUntil", () => {
+    const result = TermConfig.safeParse({ term: 202510 });
+    assert.equal(result.success, false);
+  });
+
+  test("invalid: term is string instead of int", () => {
+    const result = TermConfig.safeParse({ term: "202510", activeUntil: "2025-12-31" });
+    assert.equal(result.success, false);
+  });
+
+  test("invalid: extra unknown field rejected by strictObject", () => {
+    const result = TermConfig.safeParse({
+      term: 202510,
+      activeUntil: "2025-12-31",
+      unknownField: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("ManifestConfig", () => {
+  test("valid: terms array with one entry", () => {
+    const result = ManifestConfig.safeParse({
+      terms: [{ term: 202510, activeUntil: "2025-12-31" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("invalid: terms is not an array", () => {
+    const result = ManifestConfig.safeParse({ terms: "not-an-array" });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("PartOfTermConfig", () => {
+  test("valid: minimal with only code", () => {
+    const result = PartOfTermConfig.safeParse({ code: "A" });
+    assert.equal(result.success, true);
+  });
+
+  test("valid: with optional name and activeUntil", () => {
+    const result = PartOfTermConfig.safeParse({
+      code: "A",
+      name: "Part A",
+      activeUntil: "2025-10-15",
+    });
+    assert.equal(result.success, true);
+  });
+});

--- a/packages/scraper/src/events.test.ts
+++ b/packages/scraper/src/events.test.ts
@@ -1,0 +1,79 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { ScraperEventEmitter } from "./events.js";
+
+describe("ScraperEventEmitter", () => {
+  test("on() + emit() delivers typed data payload", () => {
+    const emitter = new ScraperEventEmitter();
+    let received: { term: string } | undefined;
+
+    emitter.on("scrape:start", (data) => {
+      received = data;
+    });
+    emitter.emit("scrape:start", { term: "202510" });
+
+    assert.deepStrictEqual(received, { term: "202510" });
+  });
+
+  test("emit() with undefined-payload event fires handler", () => {
+    const emitter = new ScraperEventEmitter();
+    let called = false;
+
+    emitter.on("scrape:detail:start", () => {
+      called = true;
+    });
+    emitter.emit("scrape:detail:start");
+
+    assert.equal(called, true);
+  });
+
+  test("on() returns unsubscribe function that removes the handler", () => {
+    const emitter = new ScraperEventEmitter();
+    let callCount = 0;
+
+    const unsub = emitter.on("scrape:start", () => {
+      callCount++;
+    });
+    emitter.emit("scrape:start", { term: "202510" });
+    assert.equal(callCount, 1);
+
+    unsub();
+    emitter.emit("scrape:start", { term: "202510" });
+    assert.equal(callCount, 1);
+  });
+
+  test("multiple handlers for the same event all fire", () => {
+    const emitter = new ScraperEventEmitter();
+    const calls: number[] = [];
+
+    emitter.on("scrape:start", () => calls.push(1));
+    emitter.on("scrape:start", () => calls.push(2));
+    emitter.on("scrape:start", () => calls.push(3));
+
+    emitter.emit("scrape:start", { term: "202510" });
+
+    assert.deepStrictEqual(calls, [1, 2, 3]);
+  });
+
+  test("emit() with no registered handlers does not throw", () => {
+    const emitter = new ScraperEventEmitter();
+
+    assert.doesNotThrow(() => {
+      emitter.emit("scrape:start", { term: "202510" });
+    });
+  });
+
+  test("handler receives the correct data object", () => {
+    const emitter = new ScraperEventEmitter();
+    let received: { batch: number; totalBatches: number } | undefined;
+
+    emitter.on("scrape:sections:progress", (data) => {
+      received = data;
+    });
+
+    const payload = { batch: 3, totalBatches: 10 };
+    emitter.emit("scrape:sections:progress", payload);
+
+    assert.deepStrictEqual(received, { batch: 3, totalBatches: 10 });
+  });
+});

--- a/packages/scraper/src/generate/endpoints.test.ts
+++ b/packages/scraper/src/generate/endpoints.test.ts
@@ -1,0 +1,83 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  baseUrl,
+  sectionSearchEndpoint,
+  sectionFacultyEndpoint,
+  sectionCatalogDetailsEndpoint,
+  courseDescriptionEndpoint,
+  sectionPrereqsEndpoint,
+  sectionCoreqsEndpoint,
+  subjectsEndpoint,
+} from "./endpoints.js";
+
+describe("baseUrl", () => {
+  test("is https://nubanner.neu.edu", () => {
+    assert.equal(baseUrl, "https://nubanner.neu.edu");
+  });
+});
+
+describe("sectionSearchEndpoint", () => {
+  test("returns correct URL with query params", () => {
+    const url = sectionSearchEndpoint("202510", 0, 25);
+    assert.equal(
+      url,
+      "https://nubanner.neu.edu/StudentRegistrationSsb/ssb/searchResults/searchResults?txt_term=202510&pageOffset=0&pageMaxSize=25",
+    );
+  });
+});
+
+describe("sectionFacultyEndpoint", () => {
+  test("returns correct URL", () => {
+    const url = sectionFacultyEndpoint("202510", "12345");
+    assert.equal(
+      url,
+      "https://nubanner.neu.edu/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=202510&courseReferenceNumber=12345",
+    );
+  });
+});
+
+function assertPostEndpoint(
+  fn: (term: string, crn: string) => readonly [string, { method: string; headers: Record<string, string>; body: string }],
+  expectedPath: string,
+) {
+  const [url, init] = fn("202510", "12345");
+  assert.equal(url, `${baseUrl}${expectedPath}`);
+  assert.equal(init.method, "POST");
+  assert.equal(init.headers["Content-Type"], "application/x-www-form-urlencoded");
+  assert.equal(init.body, "term=202510&courseReferenceNumber=12345");
+}
+
+describe("sectionCatalogDetailsEndpoint", () => {
+  test("returns [url, requestInit] tuple with POST method and form body", () => {
+    assertPostEndpoint(sectionCatalogDetailsEndpoint, "/StudentRegistrationSsb/ssb/searchResults/getSectionCatalogDetails");
+  });
+});
+
+describe("courseDescriptionEndpoint", () => {
+  test("returns [url, requestInit] tuple with POST method and form body", () => {
+    assertPostEndpoint(courseDescriptionEndpoint, "/StudentRegistrationSsb/ssb/searchResults/getCourseDescription");
+  });
+});
+
+describe("sectionPrereqsEndpoint", () => {
+  test("returns [url, requestInit] tuple with POST method and form body", () => {
+    assertPostEndpoint(sectionPrereqsEndpoint, "/StudentRegistrationSsb/ssb/searchResults/getSectionPrerequisites");
+  });
+});
+
+describe("sectionCoreqsEndpoint", () => {
+  test("returns [url, requestInit] tuple with POST method and form body", () => {
+    assertPostEndpoint(sectionCoreqsEndpoint, "/StudentRegistrationSsb/ssb/searchResults/getCorequisites");
+  });
+});
+
+describe("subjectsEndpoint", () => {
+  test("returns correct URL", () => {
+    const url = subjectsEndpoint("202510");
+    assert.equal(
+      url,
+      "https://nubanner.neu.edu/StudentRegistrationSsb/ssb/classSearch/get_subject?term=202510&offset=1&max=900",
+    );
+  });
+});

--- a/packages/scraper/src/generate/fetch.test.ts
+++ b/packages/scraper/src/generate/fetch.test.ts
@@ -1,0 +1,687 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { $fetch, FetchEngine } from "./fetch.js";
+
+function mockResponse(
+  status: number,
+  body = "",
+  statusText = "",
+): Response {
+  return new Response(body, { status, statusText });
+}
+
+const originalFetch = globalThis.fetch;
+
+// Simulates a fetch that never resolves, but rejects with AbortError when aborted
+function neverResolvingFetch(_url: string | URL | Request, init?: RequestInit): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    init?.signal?.addEventListener("abort", () => {
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    });
+  });
+}
+
+afterEach(() => {
+  nock.cleanAll();
+  globalThis.fetch = originalFetch;
+});
+
+describe("$fetch", () => {
+  test("successful request returns response", async () => {
+    globalThis.fetch = async () => mockResponse(200, "success");
+
+    const res = await $fetch("http://example.com/ok");
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.equal(body, "success");
+  });
+
+  test("retries on 429 status code", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount <= 2) return mockResponse(429, "rate limited");
+      return mockResponse(200, "ok");
+    };
+
+    const res = await $fetch(
+      "http://example.com/rate-limit",
+      {},
+      { maxRetries: 3, initialDelay: 10, jitter: false },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(callCount, 3);
+  });
+
+  test("retries on 500, 502, 503, 504 status codes", async () => {
+    for (const status of [500, 502, 503, 504]) {
+      let callCount = 0;
+      globalThis.fetch = async () => {
+        callCount++;
+        if (callCount === 1) return mockResponse(status, "error");
+        return mockResponse(200, "recovered");
+      };
+
+      const res = await $fetch(
+        "http://example.com/server-err",
+        {},
+        { maxRetries: 2, initialDelay: 10, jitter: false },
+      );
+      assert.equal(res.status, 200, `should retry on ${status}`);
+      assert.equal(callCount, 2, `should have retried once for ${status}`);
+    }
+  });
+
+  test("does NOT retry on 400, 401, 403, 404", async () => {
+    for (const status of [400, 401, 403, 404]) {
+      let callCount = 0;
+      globalThis.fetch = async () => {
+        callCount++;
+        return mockResponse(status, "client error");
+      };
+
+      const res = await $fetch(
+        "http://example.com/client-err",
+        {},
+        { maxRetries: 3, initialDelay: 10, jitter: false },
+      );
+      assert.equal(
+        res.status,
+        status,
+        `should return ${status} without retrying`,
+      );
+      assert.equal(callCount, 1, `should not retry on ${status}`);
+    }
+  });
+
+  test("custom retryOn function overrides default behavior", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount === 1) return mockResponse(403, "forbidden");
+      return mockResponse(200, "ok");
+    };
+
+    const res = await $fetch(
+      "http://example.com/custom-retry",
+      {},
+      {
+        maxRetries: 2,
+        initialDelay: 10,
+        jitter: false,
+        retryOn: (response: Response) => response.status === 403,
+      },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(callCount, 2);
+  });
+
+  test("exponential backoff: delay doubles between retries", async () => {
+    let callCount = 0;
+    const callTimestamps: number[] = [];
+    globalThis.fetch = async () => {
+      callCount++;
+      callTimestamps.push(Date.now());
+      if (callCount <= 3) return mockResponse(500, "fail");
+      return mockResponse(200, "ok");
+    };
+
+    const res = await $fetch(
+      "http://example.com/backoff",
+      {},
+      {
+        maxRetries: 3,
+        initialDelay: 50,
+        jitter: false,
+      },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(callCount, 4);
+
+    // Delays should be: 50ms (50*2^0), 100ms (50*2^1), 200ms (50*2^2)
+    // Check that the gap between calls increases
+    const gap1 = callTimestamps[1]! - callTimestamps[0]!;
+    const gap2 = callTimestamps[2]! - callTimestamps[1]!;
+    const gap3 = callTimestamps[3]! - callTimestamps[2]!;
+
+    // Allow some tolerance for timing
+    assert.ok(gap1 >= 40, `first gap ${gap1}ms should be >= 40ms (target 50ms)`);
+    assert.ok(gap2 >= 80, `second gap ${gap2}ms should be >= 80ms (target 100ms)`);
+    assert.ok(gap3 >= 160, `third gap ${gap3}ms should be >= 160ms (target 200ms)`);
+    // Verify exponential growth: each gap should be roughly double the previous
+    assert.ok(
+      gap2 > gap1 * 1.5,
+      `second gap (${gap2}ms) should be roughly double first gap (${gap1}ms)`,
+    );
+  });
+
+  test("max retries exhaustion returns last response for retryable status", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      return mockResponse(500, "fail");
+    };
+
+    const res = await $fetch(
+      "http://example.com/exhaust",
+      {},
+      { maxRetries: 1, initialDelay: 10, jitter: false },
+    );
+    assert.equal(res.status, 500);
+    assert.equal(callCount, 2);
+  });
+
+  test("timeout via AbortController throws 'Request timeout after Xms'", async () => {
+    globalThis.fetch = neverResolvingFetch;
+
+    await assert.rejects(
+      () =>
+        $fetch(
+          "http://example.com/timeout",
+          {},
+          { timeout: 50, maxRetries: 0 },
+        ),
+      (err: Error) => {
+        assert.match(err.message, /Request timeout after 50ms/);
+        return true;
+      },
+    );
+  });
+
+  test("respects user-provided abort signal", async () => {
+    const userController = new AbortController();
+    globalThis.fetch = neverResolvingFetch;
+
+    // Abort user signal after 20ms
+    setTimeout(() => userController.abort(), 20);
+
+    await assert.rejects(
+      () =>
+        $fetch(
+          "http://example.com/user-abort",
+          { signal: userController.signal },
+          { timeout: 5000, maxRetries: 0 },
+        ),
+      (err: Error) => {
+        assert.equal(err.name, "AbortError");
+        return true;
+      },
+    );
+  });
+
+  test("onRetry callback is called with (response, attempt)", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount === 1) return mockResponse(500, "fail", "Internal Server Error");
+      return mockResponse(200, "ok");
+    };
+
+    const retryCalls: Array<{
+      errorOrResponse: Error | Response;
+      attempt: number;
+    }> = [];
+
+    const res = await $fetch(
+      "http://example.com/on-retry",
+      {},
+      {
+        maxRetries: 2,
+        initialDelay: 10,
+        jitter: false,
+        onRetry: (errorOrResponse, attempt) => {
+          retryCalls.push({ errorOrResponse, attempt });
+        },
+      },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(retryCalls.length, 1);
+    assert.equal(retryCalls[0]!.attempt, 1);
+    assert.ok(retryCalls[0]!.errorOrResponse instanceof Response);
+    assert.equal(
+      (retryCalls[0]!.errorOrResponse as Response).status,
+      500,
+    );
+  });
+
+  test("jitter: false gives exact exponential delays", async () => {
+    let callCount = 0;
+    const callTimestamps: number[] = [];
+    globalThis.fetch = async () => {
+      callCount++;
+      callTimestamps.push(Date.now());
+      if (callCount <= 2) return mockResponse(500, "fail");
+      return mockResponse(200, "ok");
+    };
+
+    await $fetch(
+      "http://example.com/no-jitter",
+      {},
+      {
+        maxRetries: 3,
+        initialDelay: 50,
+        jitter: false,
+      },
+    );
+
+    assert.equal(callCount, 3);
+    // With jitter: false, delays are exactly:
+    // Retry 1 delay: 50 * 2^0 = 50ms
+    // Retry 2 delay: 50 * 2^1 = 100ms
+    const gap1 = callTimestamps[1]! - callTimestamps[0]!;
+    const gap2 = callTimestamps[2]! - callTimestamps[1]!;
+
+    // With no jitter, the delays should be close to exact values
+    assert.ok(
+      gap1 >= 45 && gap1 < 80,
+      `first delay ${gap1}ms should be ~50ms`,
+    );
+    assert.ok(
+      gap2 >= 90 && gap2 < 150,
+      `second delay ${gap2}ms should be ~100ms`,
+    );
+  });
+
+  test("maxDelay caps the backoff", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount <= 3) return mockResponse(500, "fail");
+      return mockResponse(200, "ok");
+    };
+
+    const start = Date.now();
+
+    await $fetch(
+      "http://example.com/max-delay",
+      {},
+      {
+        maxRetries: 3,
+        initialDelay: 100,
+        maxDelay: 120,
+        backoffMultiplier: 10,
+        jitter: false,
+      },
+    );
+
+    const elapsed = Date.now() - start;
+    // Without maxDelay cap, delays would be 100, 1000, 10000 = 11100ms
+    // With maxDelay=120, delays are capped: min(100*10^0, 120)=100, min(100*10^1, 120)=120, min(100*10^2, 120)=120 = 340ms total
+    assert.ok(
+      elapsed < 1000,
+      `elapsed ${elapsed}ms should be under 1000ms due to maxDelay cap`,
+    );
+    assert.equal(callCount, 4);
+  });
+
+  test("network error retries and ultimately throws", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      throw new TypeError("fetch failed");
+    };
+
+    await assert.rejects(
+      () =>
+        $fetch(
+          "http://example.com/network-error",
+          {},
+          { maxRetries: 2, initialDelay: 10, jitter: false },
+        ),
+      (err: Error) => {
+        assert.equal(err.message, "fetch failed");
+        return true;
+      },
+    );
+    assert.equal(callCount, 3); // initial + 2 retries
+  });
+
+  test("onRetry called on network error retry", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount === 1) throw new TypeError("fetch failed");
+      return mockResponse(200, "ok");
+    };
+
+    const retryCalls: Array<{
+      errorOrResponse: Error | Response;
+      attempt: number;
+    }> = [];
+
+    const res = await $fetch(
+      "http://example.com/net-err-retry",
+      {},
+      {
+        maxRetries: 2,
+        initialDelay: 10,
+        jitter: false,
+        onRetry: (errorOrResponse, attempt) => {
+          retryCalls.push({ errorOrResponse, attempt });
+        },
+      },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(retryCalls.length, 1);
+    assert.equal(retryCalls[0]!.attempt, 1);
+    assert.ok(retryCalls[0]!.errorOrResponse instanceof Error);
+    assert.equal(
+      (retryCalls[0]!.errorOrResponse as Error).message,
+      "fetch failed",
+    );
+  });
+});
+
+describe("FetchEngine", () => {
+  test("basic fetch returns response", async () => {
+    globalThis.fetch = async () => mockResponse(200, "engine success");
+
+    const engine = new FetchEngine({
+      throttleDelay: 1,
+      maxConcurrent: 5,
+    });
+
+    const res = await engine.fetch("http://example.com/engine-ok");
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.equal(body, "engine success");
+  });
+
+  test("concurrency limiting: with maxConcurrent=1, requests are serialized", async () => {
+    const order: number[] = [];
+    let activeConcurrent = 0;
+    let maxObservedConcurrent = 0;
+
+    globalThis.fetch = async (url: string | URL | Request) => {
+      activeConcurrent++;
+      maxObservedConcurrent = Math.max(
+        maxObservedConcurrent,
+        activeConcurrent,
+      );
+      await new Promise((r) => setTimeout(r, 20));
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.includes("serial-1")) order.push(1);
+      if (urlStr.includes("serial-2")) order.push(2);
+      activeConcurrent--;
+      return mockResponse(200, "ok");
+    };
+
+    const engine = new FetchEngine({
+      maxConcurrent: 1,
+      throttleDelay: 1,
+    });
+
+    const [r1, r2] = await Promise.all([
+      engine.fetch("http://example.com/serial-1"),
+      engine.fetch("http://example.com/serial-2"),
+    ]);
+
+    assert.equal(r1.status, 200);
+    assert.equal(r2.status, 200);
+    assert.deepEqual(order, [1, 2]);
+    assert.equal(
+      maxObservedConcurrent,
+      1,
+      "should never have more than 1 concurrent request",
+    );
+  });
+
+  test("queue processing: multiple requests are processed", async () => {
+    let totalCalls = 0;
+    globalThis.fetch = async () => {
+      totalCalls++;
+      return mockResponse(200, "ok");
+    };
+
+    const engine = new FetchEngine({
+      maxConcurrent: 3,
+      throttleDelay: 1,
+    });
+
+    const promises = Array.from({ length: 5 }, (_, i) =>
+      engine.fetch(`http://example.com/multi-${i}`),
+    );
+    const responses = await Promise.all(promises);
+
+    assert.equal(responses.length, 5);
+    assert.equal(totalCalls, 5);
+    for (const res of responses) {
+      assert.equal(res.status, 200);
+    }
+  });
+
+  test("retry with backoff on server errors", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount === 1) return mockResponse(500, "fail");
+      return mockResponse(200, "recovered");
+    };
+
+    const engine = new FetchEngine({
+      maxRetries: 2,
+      initialRetryDelay: 10,
+      maxRetryDelay: 100,
+      throttleDelay: 1,
+    });
+
+    const res = await engine.fetch("http://example.com/engine-retry");
+    assert.equal(res.status, 200);
+    assert.equal(callCount, 2);
+  });
+
+  test("clearQueue rejects all pending requests with 'Request cancelled: queue cleared'", async () => {
+    let fetchCallCount = 0;
+    globalThis.fetch = async () => {
+      fetchCallCount++;
+      // First request takes a while
+      if (fetchCallCount === 1) {
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      return mockResponse(200, "ok");
+    };
+
+    const engine = new FetchEngine({
+      maxConcurrent: 1,
+      throttleDelay: 1,
+    });
+
+    // Start the active request
+    const activePromise = engine
+      .fetch("http://example.com/clear-active")
+      .catch(() => null);
+
+    // Queue pending requests
+    const pendingPromises = Array.from({ length: 3 }, (_, i) =>
+      engine
+        .fetch(`http://example.com/clear-pending-${i}`)
+        .catch((err: Error) => err),
+    );
+
+    // Give time for first request to be picked up and become active
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Clear the queue
+    engine.clearQueue();
+
+    // Pending requests should be rejected
+    const results = await Promise.all(pendingPromises);
+    for (const result of results) {
+      assert.ok(result instanceof Error);
+      assert.equal(result.message, "Request cancelled: queue cleared");
+    }
+
+    // Wait for active to finish
+    await activePromise;
+  });
+
+  test("getStatus reports queueLength, activeRequests, processing", async () => {
+    let resolveRequest: (() => void) | null = null;
+    globalThis.fetch = async () => {
+      await new Promise<void>((r) => {
+        resolveRequest = r;
+      });
+      return mockResponse(200, "ok");
+    };
+
+    const engine = new FetchEngine({
+      maxConcurrent: 1,
+      throttleDelay: 1,
+    });
+
+    // Before any requests
+    const initialStatus = engine.getStatus();
+    assert.equal(initialStatus.queueLength, 0);
+    assert.equal(initialStatus.activeRequests, 0);
+    assert.equal(initialStatus.processing, false);
+
+    // Start a request
+    const promise = engine.fetch("http://example.com/status-check");
+
+    // Give time for processing to start and request to become active
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const activeStatus = engine.getStatus();
+    assert.equal(activeStatus.processing, true);
+    assert.equal(activeStatus.activeRequests, 1);
+
+    // Resolve the pending fetch
+    resolveRequest!();
+    await promise;
+  });
+
+  test("per-request maxRetries override", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount <= 2) return mockResponse(500, "fail");
+      return mockResponse(200, "ok");
+    };
+
+    const engine = new FetchEngine({
+      maxRetries: 1,
+      initialRetryDelay: 10,
+      maxRetryDelay: 50,
+      throttleDelay: 1,
+    });
+
+    const res = await engine.fetch("http://example.com/per-req-retry", {
+      maxRetries: 3,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(callCount, 3);
+  });
+
+  test("callbacks: onQueueAdd, onQueueStart, onSuccess are called", async () => {
+    globalThis.fetch = async () => mockResponse(200, "ok");
+
+    const engine = new FetchEngine({
+      throttleDelay: 1,
+    });
+
+    const calls: string[] = [];
+
+    const res = await engine.fetch("http://example.com/callbacks", {
+      onQueueAdd: () => calls.push("queueAdd"),
+      onQueueStart: () => calls.push("queueStart"),
+      onSuccess: () => calls.push("success"),
+    });
+
+    assert.equal(res.status, 200);
+    assert.ok(calls.includes("queueAdd"), "onQueueAdd should be called");
+    assert.ok(
+      calls.includes("queueStart"),
+      "onQueueStart should be called",
+    );
+    assert.ok(calls.includes("success"), "onSuccess should be called");
+    // Verify order
+    assert.ok(
+      calls.indexOf("queueAdd") < calls.indexOf("queueStart"),
+      "queueAdd before queueStart",
+    );
+    assert.ok(
+      calls.indexOf("queueStart") < calls.indexOf("success"),
+      "queueStart before success",
+    );
+  });
+
+  test("callback: onRetry is called on server error retry", async () => {
+    let callCount = 0;
+    globalThis.fetch = async () => {
+      callCount++;
+      if (callCount === 1) return mockResponse(500, "fail");
+      return mockResponse(200, "ok");
+    };
+
+    const engine = new FetchEngine({
+      maxRetries: 2,
+      initialRetryDelay: 10,
+      maxRetryDelay: 50,
+      throttleDelay: 1,
+    });
+
+    const retryCalls: Array<{ attempt: number; delay: number }> = [];
+
+    await engine.fetch("http://example.com/cb-retry", {
+      onRetry: (attempt, delay) => {
+        retryCalls.push({ attempt, delay });
+      },
+    });
+
+    assert.equal(retryCalls.length, 1);
+    assert.equal(retryCalls[0]!.attempt, 1);
+    assert.ok(retryCalls[0]!.delay > 0);
+  });
+
+  test("callback: onError is called on failure", async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+
+    const engine = new FetchEngine({
+      maxRetries: 1,
+      initialRetryDelay: 10,
+      maxRetryDelay: 50,
+      throttleDelay: 1,
+    });
+
+    const errors: Error[] = [];
+
+    try {
+      await engine.fetch("http://example.com/cb-error", {
+        maxRetries: 1,
+        onError: (err) => errors.push(err),
+      });
+    } catch {
+      // expected to throw
+    }
+
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0] instanceof Error);
+  });
+
+  test("updateConfig changes runtime configuration", async () => {
+    globalThis.fetch = async () => mockResponse(200, "ok");
+
+    const engine = new FetchEngine({
+      maxConcurrent: 5,
+      throttleDelay: 100,
+    });
+
+    engine.updateConfig({ maxConcurrent: 10, throttleDelay: 50 });
+
+    const res = await engine.fetch("http://example.com/updated-config");
+    assert.equal(res.status, 200);
+
+    // Allow the processQueue loop to finish its final iteration
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Verify updateConfig works by checking status still reports correctly
+    const status = engine.getStatus();
+    assert.equal(status.processing, false);
+  });
+});

--- a/packages/scraper/src/generate/marshall.test.ts
+++ b/packages/scraper/src/generate/marshall.test.ts
@@ -1,0 +1,542 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { arrangeCourses, parseMeetingTimes } from "./marshall";
+import { ScraperEventEmitter } from "../events";
+import type * as z from "zod";
+import type { BannerSection } from "../schemas/banner/section";
+
+/**
+ * Helper: build a minimal valid BannerSection conforming to the strict Zod schema.
+ * Every required field is present; callers override specific fields via `overrides`.
+ */
+function makeBannerSection(
+  overrides: Partial<z.infer<typeof BannerSection>> = {},
+): z.infer<typeof BannerSection> {
+  return {
+    id: 1,
+    term: "202610",
+    termDesc: "Spring 2026",
+    courseReferenceNumber: "12345",
+    partOfTerm: "1",
+    courseNumber: "2500",
+    subject: "CS",
+    subjectDescription: "Computer Science",
+    sequenceNumber: "01",
+    campusDescription: "Boston",
+    scheduleTypeDescription: "Lecture",
+    courseTitle: "Fundamentals of Computer Science 1",
+    creditHours: null,
+    maximumEnrollment: 100,
+    enrollment: 80,
+    seatsAvailable: 20,
+    waitCapacity: 10,
+    waitCount: 2,
+    waitAvailable: 8,
+    crossList: null,
+    crossListCapacity: null,
+    crossListCount: null,
+    crossListAvailable: null,
+    creditHourHigh: null,
+    creditHourLow: 4,
+    creditHourIndicator: null,
+    openSection: true,
+    linkIdentifier: null,
+    isSectionLinked: false,
+    subjectCourse: "CS2500",
+    faculty: [],
+    meetingsFaculty: [],
+    reservedSeatSummary: null,
+    sectionAttributes: [],
+    instructionalMethod: null,
+    instructionalMethodDescription: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Helper: build a single meetingsFaculty entry that conforms to BannerSectionMeetingsFaculty.
+ */
+function makeMeetingsFaculty(
+  meetingTimeOverrides: Record<string, unknown> = {},
+) {
+  return {
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingFaculty",
+    courseReferenceNumber: "12345",
+    faculty: [],
+    meetingTime: {
+      beginTime: "0800",
+      building: "WV",
+      buildingDescription: "West Village H",
+      campus: "BOS",
+      campusDescription: "Boston",
+      category: "01",
+      class:
+        "net.hedtech.banner.student.schedule.SectionSessionMeetingDecorator",
+      courseReferenceNumber: "12345",
+      creditHourSession: null,
+      endDate: "04/20/2026",
+      endTime: "0940",
+      friday: false,
+      hoursWeek: 2.66,
+      meetingScheduleType: "LEC",
+      meetingType: "CLAS",
+      meetingTypeDescription: "Class",
+      monday: true,
+      room: "212",
+      saturday: false,
+      startDate: "01/05/2026",
+      sunday: false,
+      term: "202610",
+      thursday: false,
+      tuesday: false,
+      wednesday: true,
+      ...meetingTimeOverrides,
+    },
+    term: "202610",
+  };
+}
+
+describe("parseMeetingTimes", () => {
+  test("converts day booleans to array indices (0-6)", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({
+          sunday: true,
+          monday: false,
+          tuesday: true,
+          wednesday: false,
+          thursday: true,
+          friday: false,
+          saturday: true,
+        }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes.length, 1);
+    assert.deepStrictEqual(meetingTimes[0].days, [0, 2, 4, 6]);
+  });
+
+  test("parses time strings to integers", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({ beginTime: "0800", endTime: "1430" }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].startTime, 800);
+    assert.equal(meetingTimes[0].endTime, 1430);
+  });
+
+  test("skips meetings with null beginTime", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({ beginTime: null, endTime: "0940" }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes.length, 0);
+  });
+
+  test("skips meetings with null endTime", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({ beginTime: "0800", endTime: null }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes.length, 0);
+  });
+
+  test("detects final exam via meetingTypeDescription", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({
+          meetingTypeDescription: "Final Exam",
+          meetingType: "CLAS",
+          startDate: "04/20/2026",
+        }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].final, true);
+    assert.equal(meetingTimes[0].finalDate, "04/20/2026");
+  });
+
+  test("detects final exam via meetingType FNEX", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({
+          meetingTypeDescription: "Something Else",
+          meetingType: "FNEX",
+          startDate: "04/22/2026",
+        }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].final, true);
+    assert.equal(meetingTimes[0].finalDate, "04/22/2026");
+  });
+
+  test("sets finalDate to null for non-final meetings", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({
+          meetingTypeDescription: "Class",
+          meetingType: "CLAS",
+          startDate: "01/05/2026",
+        }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].final, false);
+    assert.equal(meetingTimes[0].finalDate, null);
+  });
+
+  test("normalizes room 'ROOM' to null", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [makeMeetingsFaculty({ room: "ROOM" })],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].room, null);
+  });
+
+  test("normalizes null room to null", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [makeMeetingsFaculty({ room: null })],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].room, null);
+  });
+
+  test("passes through actual room value", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [makeMeetingsFaculty({ room: "212" })],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes[0].room, "212");
+  });
+
+  test("passes through building, buildingDescription, campus, campusDescription", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({
+          building: "WV",
+          buildingDescription: "West Village H",
+          campus: "BOS",
+          campusDescription: "Boston",
+        }),
+      ],
+    });
+
+    const { meetingTimes } = parseMeetingTimes(section);
+    const mt = meetingTimes[0];
+    assert.equal(mt.building, "WV");
+    assert.equal(mt.buildingDescription, "West Village H");
+    assert.equal(mt.campus, "BOS");
+    assert.equal(mt.campusDescription, "Boston");
+  });
+
+  test("returns empty meetingTimes for section with no meetingsFaculty", () => {
+    const section = makeBannerSection({ meetingsFaculty: [] });
+    const { meetingTimes } = parseMeetingTimes(section);
+    assert.equal(meetingTimes.length, 0);
+  });
+});
+
+describe("arrangeCourses", () => {
+  test("creates course stubs from banner sections", () => {
+    const section = makeBannerSection({
+      subject: "CS",
+      courseNumber: "2500",
+      courseTitle: "Fundies 1",
+      creditHourLow: 4,
+      creditHourHigh: null,
+      subjectCourse: "CS2500",
+      sectionAttributes: [],
+    });
+
+    const result = arrangeCourses([section]);
+    assert.equal(result.courses.length, 1);
+
+    const course = result.courses[0];
+    assert.equal(course.subject, "CS");
+    assert.equal(course.courseNumber, "2500");
+    assert.equal(course.name, "Fundies 1");
+    assert.equal(course.minCredits, 4);
+    assert.equal(course.maxCredits, 4);
+    assert.equal(course.specialTopics, false);
+    assert.equal(course.description, "");
+  });
+
+  test("uses creditHourHigh for maxCredits when present", () => {
+    const section = makeBannerSection({
+      creditHourLow: 1,
+      creditHourHigh: 4,
+    });
+
+    const result = arrangeCourses([section]);
+    assert.equal(result.courses[0].maxCredits, 4);
+    assert.equal(result.courses[0].minCredits, 1);
+  });
+
+  test("detects special topics via title containing 'Special Topics'", () => {
+    const section = makeBannerSection({
+      courseTitle: "Special Topics in AI",
+      subjectCourse: "CS4991",
+      courseNumber: "4991",
+    });
+
+    const result = arrangeCourses([section]);
+    assert.equal(result.courses[0].specialTopics, true);
+    assert.equal(result.courses[0].name, "Special Topics");
+  });
+
+  test("detects special topics via TOPC attribute code", () => {
+    const section1 = makeBannerSection({
+      courseReferenceNumber: "11111",
+      courseTitle: "Machine Learning",
+      subjectCourse: "CS4991",
+      courseNumber: "4991",
+      sectionAttributes: [],
+    });
+
+    const section2 = makeBannerSection({
+      courseReferenceNumber: "22222",
+      courseTitle: "Data Mining",
+      subjectCourse: "CS4991",
+      courseNumber: "4991",
+      sectionAttributes: [
+        {
+          class: "net.hedtech.banner.student.schedule.SectionDecorator",
+          code: "TOPC",
+          courseReferenceNumber: "22222",
+          description: "Topics Course",
+          isZTCAttribute: false,
+          termCode: "202610",
+        },
+      ],
+    });
+
+    const result = arrangeCourses([section1, section2]);
+    assert.equal(result.courses[0].specialTopics, true);
+    assert.equal(result.courses[0].name, "Special Topics");
+  });
+
+  test("maps sections to their course key (subjectCourse)", () => {
+    const sec1 = makeBannerSection({
+      courseReferenceNumber: "11111",
+      subjectCourse: "CS2500",
+      courseNumber: "2500",
+      sequenceNumber: "01",
+    });
+    const sec2 = makeBannerSection({
+      courseReferenceNumber: "22222",
+      subjectCourse: "CS2500",
+      courseNumber: "2500",
+      sequenceNumber: "02",
+    });
+    const sec3 = makeBannerSection({
+      courseReferenceNumber: "33333",
+      subjectCourse: "CS3500",
+      courseNumber: "3500",
+      subject: "CS",
+      courseTitle: "Object-Oriented Design",
+    });
+
+    const result = arrangeCourses([sec1, sec2, sec3]);
+    assert.equal(result.sections["CS2500"].length, 2);
+    assert.equal(result.sections["CS3500"].length, 1);
+  });
+
+  test("tracks crosslist IDs and CRN arrays", () => {
+    const sec1 = makeBannerSection({
+      courseReferenceNumber: "11111",
+      subjectCourse: "CS2500",
+      courseNumber: "2500",
+      crossList: "XL01",
+      crossListCapacity: 200,
+      crossListCount: 150,
+      crossListAvailable: 50,
+    });
+    const sec2 = makeBannerSection({
+      courseReferenceNumber: "22222",
+      subjectCourse: "CS2501",
+      courseNumber: "2501",
+      courseTitle: "Lab for CS 2500",
+      crossList: "XL01",
+      crossListCapacity: 200,
+      crossListCount: 150,
+      crossListAvailable: 50,
+    });
+
+    const result = arrangeCourses([sec1, sec2]);
+
+    const cs2500Sec = result.sections["CS2500"][0];
+    const cs2501Sec = result.sections["CS2501"][0];
+
+    assert.ok(cs2500Sec.xlist.includes("11111"));
+    assert.ok(cs2500Sec.xlist.includes("22222"));
+    assert.ok(cs2501Sec.xlist.includes("11111"));
+    assert.ok(cs2501Sec.xlist.includes("22222"));
+  });
+
+  test("collects unique attributes from sections", () => {
+    const section = makeBannerSection({
+      sectionAttributes: [
+        {
+          class: "net.hedtech.banner.student.schedule.SectionDecorator",
+          code: "HNRS",
+          courseReferenceNumber: "12345",
+          description: "Honors ",
+          isZTCAttribute: false,
+          termCode: "202610",
+        },
+        {
+          class: "net.hedtech.banner.student.schedule.SectionDecorator",
+          code: "NUPATH",
+          courseReferenceNumber: "12345",
+          description: "NUpath ",
+          isZTCAttribute: false,
+          termCode: "202610",
+        },
+      ],
+    });
+
+    const result = arrangeCourses([section]);
+
+    assert.equal(result.attributes.get("HNRS"), "Honors");
+    assert.equal(result.attributes.get("NUPATH"), "NUpath");
+
+    assert.ok(result.courses[0].attributes.includes("HNRS"));
+    assert.ok(result.courses[0].attributes.includes("NUPATH"));
+  });
+
+  test("uses crossListCapacity/crossListAvailable when crossList is present", () => {
+    const section = makeBannerSection({
+      crossList: "XL01",
+      crossListCapacity: 200,
+      crossListCount: 150,
+      crossListAvailable: 50,
+      maximumEnrollment: 100,
+      seatsAvailable: 20,
+    });
+
+    const result = arrangeCourses([section]);
+    const sec = result.sections["CS2500"][0];
+    assert.equal(sec.seatCapacity, 200);
+    assert.equal(sec.seatRemaining, 50);
+  });
+
+  test("falls back to maximumEnrollment/seatsAvailable when no crossList", () => {
+    const section = makeBannerSection({
+      crossList: null,
+      crossListCapacity: null,
+      crossListAvailable: null,
+      maximumEnrollment: 100,
+      seatsAvailable: 20,
+    });
+
+    const result = arrangeCourses([section]);
+    const sec = result.sections["CS2500"][0];
+    assert.equal(sec.seatCapacity, 100);
+    assert.equal(sec.seatRemaining, 20);
+  });
+
+  test("multiple sections for the same course", () => {
+    const sec1 = makeBannerSection({
+      courseReferenceNumber: "11111",
+      sequenceNumber: "01",
+      courseTitle: "Fundies 1",
+      subjectCourse: "CS2500",
+    });
+    const sec2 = makeBannerSection({
+      courseReferenceNumber: "22222",
+      sequenceNumber: "02",
+      courseTitle: "Fundies 1",
+      subjectCourse: "CS2500",
+    });
+
+    const result = arrangeCourses([sec1, sec2]);
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.sections["CS2500"].length, 2);
+    assert.equal(result.sections["CS2500"][0].crn, "11111");
+    assert.equal(result.sections["CS2500"][1].crn, "22222");
+    assert.equal(result.sections["CS2500"][0].sectionNumber, "01");
+    assert.equal(result.sections["CS2500"][1].sectionNumber, "02");
+  });
+
+  test("empty input returns empty structures", () => {
+    const result = arrangeCourses([]);
+    assert.equal(result.courses.length, 0);
+    assert.deepStrictEqual(result.sections, {});
+    assert.equal(result.attributes.size, 0);
+  });
+
+  test("emits scrape:courses:stubbed event when emitter is provided", () => {
+    const emitter = new ScraperEventEmitter();
+    let emitted = false;
+    emitter.on("scrape:courses:stubbed", () => {
+      emitted = true;
+    });
+
+    arrangeCourses([], emitter);
+    assert.equal(emitted, true);
+  });
+
+  test("section honors flag derived from sectionAttributes", () => {
+    const section = makeBannerSection({
+      sectionAttributes: [
+        {
+          class: "net.hedtech.banner.student.schedule.SectionDecorator",
+          code: "HNRS",
+          courseReferenceNumber: "12345",
+          description: "Honors",
+          isZTCAttribute: false,
+          termCode: "202610",
+        },
+      ],
+    });
+
+    const result = arrangeCourses([section]);
+    assert.equal(result.sections["CS2500"][0].honors, true);
+  });
+
+  test("section honors flag is false when no Honors attribute", () => {
+    const section = makeBannerSection({ sectionAttributes: [] });
+    const result = arrangeCourses([section]);
+    assert.equal(result.sections["CS2500"][0].honors, false);
+  });
+
+  test("section includes parsed meeting times", () => {
+    const section = makeBannerSection({
+      meetingsFaculty: [
+        makeMeetingsFaculty({
+          monday: true,
+          wednesday: true,
+          friday: false,
+          beginTime: "1335",
+          endTime: "1515",
+        }),
+      ],
+    });
+
+    const result = arrangeCourses([section]);
+    const mt = result.sections["CS2500"][0].meetingTimes;
+    assert.equal(mt.length, 1);
+    assert.deepStrictEqual(mt[0].days, [1, 3]);
+    assert.equal(mt[0].startTime, 1335);
+    assert.equal(mt[0].endTime, 1515);
+  });
+});

--- a/packages/scraper/src/generate/steps/campuses.test.ts
+++ b/packages/scraper/src/generate/steps/campuses.test.ts
@@ -1,0 +1,47 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { scrapeCampuses } from "./campuses";
+import { ScraperEventEmitter } from "../../events";
+
+const BASE = "https://nubanner.neu.edu";
+const CAMPUSES_PATH =
+  "/StudentRegistrationSsb/ssb/classSearch/get_campus";
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("scrapeCampuses", () => {
+  test("returns array of campus objects on success", async () => {
+    nock(BASE)
+      .get(CAMPUSES_PATH)
+      .query({ searchTerm: "", term: "202510", offset: "1", max: "100" })
+      .reply(200, [
+        { code: "BOS", description: "Boston" },
+        { code: "OAK", description: "Oakland" },
+      ]);
+
+    const result = await scrapeCampuses("202510");
+    assert.deepStrictEqual(result, [
+      { code: "BOS", description: "Boston" },
+      { code: "OAK", description: "Oakland" },
+    ]);
+  });
+
+  test("returns undefined and emits error on parse failure", async () => {
+    nock(BASE)
+      .get(CAMPUSES_PATH)
+      .query({ searchTerm: "", term: "202510", offset: "1", max: "100" })
+      .reply(200, { unexpected: "format" });
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { message: string }[] = [];
+    emitter.on("error", (data) => errors.push(data));
+
+    const result = await scrapeCampuses("202510", emitter);
+    assert.equal(result, undefined);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].message, "error parsing banner campus info");
+  });
+});

--- a/packages/scraper/src/generate/steps/courseCoreqs.test.ts
+++ b/packages/scraper/src/generate/steps/courseCoreqs.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeCourseCoreqs } from "./courseCoreqs";
+import { ScraperEventEmitter } from "../../events";
+
+const fe = new FetchEngine({
+  maxConcurrent: 1,
+  throttleDelay: 0,
+  initialRetryDelay: 10,
+  maxRetries: 0,
+});
+
+const subjects = [
+  { code: "CS", description: "Computer Science" },
+  { code: "MATH", description: "Mathematics" },
+];
+
+const BANNER_BASE = "https://nubanner.neu.edu";
+const COREQS_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/getCorequisites";
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("scrapeCourseCoreqs", () => {
+  test("successfully fetches and parses coreqs, updates item in place", async () => {
+    const html = `<table><tbody>
+<tr><td>Computer Science</td><td>2501</td><td> </td></tr>
+</tbody></table>`;
+
+    nock(BANNER_BASE)
+      .post(COREQS_PATH, `term=202410&courseReferenceNumber=12345`)
+      .reply(200, html);
+
+    const items = [{ crn: "12345", prereqs: {} as any }] as any[];
+    const failed = await scrapeCourseCoreqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.deepEqual(items[0].coreqs, {
+      subject: "CS",
+      courseNumber: "2501",
+    });
+  });
+
+  test("null/empty response leaves coreqs unchanged", async () => {
+    nock(BANNER_BASE)
+      .post(COREQS_PATH, `term=202410&courseReferenceNumber=12345`)
+      .reply(200, "");
+
+    const items = [{ crn: "12345", prereqs: {} as any }] as any[];
+    const failed = await scrapeCourseCoreqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.equal(items[0].coreqs, undefined);
+  });
+
+  test("fetch failure adds CRN to failed list and emits fetch:error", async () => {
+    nock(BANNER_BASE)
+      .post(COREQS_PATH, `term=202410&courseReferenceNumber=99999`)
+      .replyWithError("connection refused");
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+    emitter.on("fetch:error", (data) => errors.push(data));
+
+    const items = [{ crn: "99999", prereqs: {} as any }] as any[];
+    const failed = await scrapeCourseCoreqs(
+      fe,
+      "202410",
+      items,
+      subjects,
+      emitter,
+    );
+
+    assert.ok(failed.includes("99999"));
+    assert.ok(errors.length >= 1);
+    assert.equal(errors[0].crn, "99999");
+    assert.equal(errors[0].step, "coreqs");
+  });
+
+  test("multiple items are all processed", async () => {
+    const html1 = `<table><tbody>
+<tr><td>Computer Science</td><td>2501</td><td> </td></tr>
+</tbody></table>`;
+
+    const html2 = `<table><tbody>
+<tr><td>Mathematics</td><td>2331</td><td> </td></tr>
+</tbody></table>`;
+
+    nock(BANNER_BASE)
+      .post(COREQS_PATH, `term=202410&courseReferenceNumber=10001`)
+      .reply(200, html1)
+      .post(COREQS_PATH, `term=202410&courseReferenceNumber=10002`)
+      .reply(200, html2);
+
+    const items = [
+      { crn: "10001", prereqs: {} as any },
+      { crn: "10002", prereqs: {} as any },
+    ] as any[];
+    const failed = await scrapeCourseCoreqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.deepEqual(items[0].coreqs, {
+      subject: "CS",
+      courseNumber: "2501",
+    });
+    assert.deepEqual(items[1].coreqs, {
+      subject: "MATH",
+      courseNumber: "2331",
+    });
+  });
+});

--- a/packages/scraper/src/generate/steps/courseDescriptions.test.ts
+++ b/packages/scraper/src/generate/steps/courseDescriptions.test.ts
@@ -1,0 +1,181 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeCourseDescriptions } from "./courseDescriptions";
+import { ScraperEventEmitter } from "../../events";
+
+const BASE_URL = "https://nubanner.neu.edu";
+const TERM = "202510";
+const POST_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/getCourseDescription";
+
+function makeFe() {
+  return new FetchEngine({
+    maxConcurrent: 1,
+    throttleDelay: 0,
+    initialRetryDelay: 10,
+    maxRetries: 0,
+  });
+}
+
+function makeItem(crn: string) {
+  return { crn, description: "" };
+}
+
+describe("scrapeCourseDescriptions", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("successfully extracts description and updates item in place", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Introduction to algorithms and data structures.");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(
+      item.description,
+      "Introduction to algorithms and data structures.",
+    );
+  });
+
+  test("removes HTML tags from description", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<p>This course covers <b>advanced</b> topics in <em>CS</em>.</p>",
+      );
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(
+      item.description,
+      "This course covers advanced topics in CS.",
+    );
+  });
+
+  test("removes HTML comments from description", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "Some text<!-- this is a comment --> and more text.",
+      );
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Some text and more text.");
+  });
+
+  test("handles double HTML-encoded entities", async () => {
+    const item = makeItem("12345");
+
+    // &amp;amp; -> first decode -> &amp; -> second decode -> &
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Algorithms &amp;amp; Data Structures");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Algorithms & Data Structures");
+  });
+
+  test("trims whitespace from description", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "   Some description with whitespace   ");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Some description with whitespace");
+  });
+
+  test("returns failed CRNs on fetch failure", async () => {
+    const item = makeItem("99999");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=99999`)
+      .replyWithError("connection refused");
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, ["99999", "99999"]);
+    assert.equal(item.description, "");
+  });
+
+  test("emits fetch:error event on failure", async () => {
+    const item = makeItem("77777");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=77777`)
+      .replyWithError("timeout");
+
+    await scrapeCourseDescriptions(makeFe(), TERM, [item], emitter);
+
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0].crn, "77777");
+    assert.equal(errors[0].step, "description");
+    assert.ok(errors[0].message.includes("timeout"));
+  });
+
+  test("processes multiple items", async () => {
+    const item1 = makeItem("11111");
+    const item2 = makeItem("22222");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=11111`)
+      .reply(200, "First description.");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=22222`)
+      .reply(200, "Second description.");
+
+    const failed = await scrapeCourseDescriptions(
+      makeFe(),
+      TERM,
+      [item1, item2],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(item1.description, "First description.");
+    assert.equal(item2.description, "Second description.");
+  });
+
+  test("handles combined HTML tags, comments, and entities", async () => {
+    const item = makeItem("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<!-- comment --><p>Study of &amp;amp; in <b>depth</b>.</p><!-- end -->",
+      );
+
+    const failed = await scrapeCourseDescriptions(makeFe(), TERM, [item]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(item.description, "Study of & in depth.");
+  });
+});

--- a/packages/scraper/src/generate/steps/courseNames.test.ts
+++ b/packages/scraper/src/generate/steps/courseNames.test.ts
@@ -1,0 +1,173 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeCatalogDetails } from "./courseNames";
+import { ScraperEventEmitter } from "../../events";
+import type { Course } from "../../types";
+
+const BASE_URL = "https://nubanner.neu.edu";
+const TERM = "202510";
+const POST_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/getSectionCatalogDetails";
+
+function makeFe() {
+  return new FetchEngine({
+    maxConcurrent: 1,
+    throttleDelay: 0,
+    initialRetryDelay: 10,
+    maxRetries: 0,
+  });
+}
+
+function makeCourse(crn: string): Course & { crn: string } {
+  return {
+    subject: "CS",
+    courseNumber: "2500",
+    specialTopics: false,
+    name: "",
+    description: "",
+    maxCredits: 4,
+    minCredits: 4,
+    attributes: [],
+    coreqs: {},
+    prereqs: {},
+    postreqs: {},
+    crn,
+  };
+}
+
+describe("scrapeCatalogDetails", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("successfully extracts title from HTML response", async () => {
+    const course = makeCourse("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<br/>\nTitle:Fundamentals of Computer Science\n<br/>Some other info",
+      );
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Fundamentals of Computer Science");
+  });
+
+  test("strips HTML tags from response before extracting title", async () => {
+    const course = makeCourse("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(
+        200,
+        "<p><b>Title:</b><em>Algorithms &amp;amp; Data</em></p>",
+      );
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Algorithms & Data");
+  });
+
+  test("falls back to 'Unknown' when no Title: line is present", async () => {
+    const course = makeCourse("12345");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Some random catalog text with no title line");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Unknown");
+  });
+
+  test("returns failed CRNs on fetch failure", async () => {
+    const course = makeCourse("99999");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=99999`)
+      .replyWithError("connection refused");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, ["99999", "99999"]);
+    assert.equal(course.name, "");
+  });
+
+  test("returns failed CRNs when fetch error causes undefined response", async () => {
+    const course = makeCourse("88888");
+
+    // A fetch error returns undefined, which fails z.string() parse
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=88888`)
+      .replyWithError("server error");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, ["88888", "88888"]);
+  });
+
+  test("emits fetch:error on failure", async () => {
+    const course = makeCourse("77777");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=77777`)
+      .replyWithError("timeout");
+
+    await scrapeCatalogDetails(makeFe(), TERM, [course], emitter);
+
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0].crn, "77777");
+    assert.equal(errors[0].step, "catalog-details");
+    assert.ok(errors[0].message.includes("timeout"));
+  });
+
+  test("handles double HTML-encoded entities", async () => {
+    const course = makeCourse("12345");
+
+    // &amp;amp; -> first decode -> &amp; -> second decode -> &
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=12345`)
+      .reply(200, "Title:Algorithms &amp;amp; Data Structures");
+
+    const failed = await scrapeCatalogDetails(makeFe(), TERM, [course]);
+
+    assert.deepEqual(failed, []);
+    assert.equal(course.name, "Algorithms & Data Structures");
+  });
+
+  test("processes multiple courses", async () => {
+    const course1 = makeCourse("11111");
+    const course2 = makeCourse("22222");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=11111`)
+      .reply(200, "Title:Algorithms");
+
+    nock(BASE_URL)
+      .post(POST_PATH, `term=${TERM}&courseReferenceNumber=22222`)
+      .reply(200, "Title:Networks");
+
+    const failed = await scrapeCatalogDetails(
+      makeFe(),
+      TERM,
+      [course1, course2],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(course1.name, "Algorithms");
+    assert.equal(course2.name, "Networks");
+  });
+});

--- a/packages/scraper/src/generate/steps/coursePrereqs.test.ts
+++ b/packages/scraper/src/generate/steps/coursePrereqs.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeCoursePrereqs } from "./coursePrereqs";
+import { ScraperEventEmitter } from "../../events";
+
+const fe = new FetchEngine({
+  maxConcurrent: 1,
+  throttleDelay: 0,
+  initialRetryDelay: 10,
+  maxRetries: 0,
+});
+
+const subjects = [
+  { code: "CS", description: "Computer Science" },
+  { code: "MATH", description: "Mathematics" },
+];
+
+const BANNER_BASE = "https://nubanner.neu.edu";
+const PREREQS_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/getSectionPrerequisites";
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("scrapeCoursePrereqs", () => {
+  test("successfully fetches and parses prereqs, updates item in place", async () => {
+    const html = `<table><tbody>
+<tr><td></td><td></td><td></td><td></td><td>Computer Science</td><td>2500</td><td></td><td></td><td></td></tr>
+</tbody></table>`;
+
+    nock(BANNER_BASE)
+      .post(PREREQS_PATH, `term=202410&courseReferenceNumber=12345`)
+      .reply(200, html);
+
+    const items = [{ crn: "12345", prereqs: {} as any }];
+    const failed = await scrapeCoursePrereqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.deepEqual(items[0].prereqs, {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+  });
+
+  test("null/empty response leaves prereqs unchanged", async () => {
+    nock(BANNER_BASE)
+      .post(PREREQS_PATH, `term=202410&courseReferenceNumber=12345`)
+      .reply(200, "");
+
+    const originalPrereqs = {};
+    const items = [{ crn: "12345", prereqs: originalPrereqs as any }];
+    const failed = await scrapeCoursePrereqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.equal(items[0].prereqs, originalPrereqs);
+  });
+
+  test("fetch failure adds CRN to failed list and emits fetch:error", async () => {
+    nock(BANNER_BASE)
+      .post(PREREQS_PATH, `term=202410&courseReferenceNumber=99999`)
+      .replyWithError("connection refused");
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+    emitter.on("fetch:error", (data) => errors.push(data));
+
+    const items = [{ crn: "99999", prereqs: {} as any }];
+    const failed = await scrapeCoursePrereqs(
+      fe,
+      "202410",
+      items,
+      subjects,
+      emitter,
+    );
+
+    // CRN appears twice: once from fetch catch, once from zod parse of undefined
+    assert.ok(failed.includes("99999"));
+    assert.ok(errors.length >= 1);
+    assert.equal(errors[0].crn, "99999");
+    assert.equal(errors[0].step, "prereqs");
+  });
+
+  test("HTML entities are double-decoded before parsing", async () => {
+    // Server returns double-encoded HTML: first decode yields &lt;/&gt; entities,
+    // second decode yields actual angle brackets.
+    const doubleEncoded = `&lt;table&gt;&lt;tbody&gt;
+&lt;tr&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;Mathematics&lt;/td&gt;&lt;td&gt;1341&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;/tr&gt;
+&lt;/tbody&gt;&lt;/table&gt;`;
+
+    nock(BANNER_BASE)
+      .post(PREREQS_PATH, `term=202410&courseReferenceNumber=11111`)
+      .reply(200, doubleEncoded);
+
+    const items = [{ crn: "11111", prereqs: {} as any }];
+    const failed = await scrapeCoursePrereqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.deepEqual(items[0].prereqs, {
+      subject: "MATH",
+      courseNumber: "1341",
+    });
+  });
+
+  test("multiple items are all processed", async () => {
+    const html1 = `<table><tbody>
+<tr><td></td><td></td><td></td><td></td><td>Computer Science</td><td>2500</td><td></td><td></td><td></td></tr>
+</tbody></table>`;
+
+    const html2 = `<table><tbody>
+<tr><td></td><td></td><td></td><td></td><td>Mathematics</td><td>2331</td><td></td><td></td><td></td></tr>
+</tbody></table>`;
+
+    nock(BANNER_BASE)
+      .post(PREREQS_PATH, `term=202410&courseReferenceNumber=10001`)
+      .reply(200, html1)
+      .post(PREREQS_PATH, `term=202410&courseReferenceNumber=10002`)
+      .reply(200, html2);
+
+    const items = [
+      { crn: "10001", prereqs: {} as any },
+      { crn: "10002", prereqs: {} as any },
+    ];
+    const failed = await scrapeCoursePrereqs(fe, "202410", items, subjects);
+
+    assert.deepEqual(failed, []);
+    assert.deepEqual(items[0].prereqs, {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.deepEqual(items[1].prereqs, {
+      subject: "MATH",
+      courseNumber: "2331",
+    });
+  });
+});

--- a/packages/scraper/src/generate/steps/meetingsFaculty.test.ts
+++ b/packages/scraper/src/generate/steps/meetingsFaculty.test.ts
@@ -1,0 +1,295 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { FetchEngine } from "../fetch";
+import { scrapeMeetingsFaculty } from "./meetingsFaculty";
+import { ScraperEventEmitter } from "../../events";
+import type { Section } from "../../types";
+
+const BASE_URL = "https://nubanner.neu.edu";
+const TERM = "202510";
+
+function makeFe() {
+  return new FetchEngine({
+    maxConcurrent: 1,
+    throttleDelay: 0,
+    initialRetryDelay: 10,
+    maxRetries: 0,
+  });
+}
+
+function makeSection(crn: string): Section {
+  return {
+    crn,
+    name: "",
+    description: "",
+    sectionNumber: "01",
+    partOfTerm: "1",
+    seatCapacity: 30,
+    seatRemaining: 10,
+    waitlistCapacity: 0,
+    waitlistRemaining: 0,
+    classType: "Lecture",
+    honors: false,
+    campus: "BOS",
+    meetingTimes: [],
+    faculty: [],
+    xlist: [],
+    coreqs: {},
+    prereqs: {},
+  };
+}
+
+function makeFacultyResponse(
+  crn: string,
+  term: string,
+  faculty: {
+    displayName: string;
+    emailAddress: string | null;
+    primaryIndicator: boolean;
+    bannerId?: string;
+  }[],
+) {
+  return {
+    fmt: [
+      {
+        category: "01",
+        class: "net.hedtech.banner.general.overall.SectionMeetingTimeView",
+        courseReferenceNumber: crn,
+        faculty: faculty.map((f) => ({
+          bannerId: f.bannerId ?? "12345",
+          category: "01",
+          class:
+            "net.hedtech.banner.general.overall.SectionMeetingTimeFacultyView",
+          courseReferenceNumber: crn,
+          displayName: f.displayName,
+          emailAddress: f.emailAddress,
+          primaryIndicator: f.primaryIndicator,
+          term,
+        })),
+        meetingTime: {
+          beginTime: "0800",
+          building: "SN",
+          buildingDescription: "Snell Library",
+          campus: "BOS",
+          campusDescription: "Boston",
+          category: "01",
+          class:
+            "net.hedtech.banner.general.overall.SectionMeetingTimeView",
+          courseReferenceNumber: crn,
+          creditHourSession: 4,
+          endDate: "12/10/2025",
+          endTime: "0940",
+          friday: false,
+          hoursWeek: 2.66,
+          meetingScheduleType: "LEC",
+          meetingType: "CLAS",
+          meetingTypeDescription: "Class",
+          monday: true,
+          room: "108",
+          saturday: false,
+          startDate: "09/01/2025",
+          sunday: false,
+          term,
+          thursday: false,
+          tuesday: false,
+          wednesday: true,
+        },
+        term,
+      },
+    ],
+  };
+}
+
+describe("scrapeMeetingsFaculty", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("successfully extracts faculty and updates section in place", async () => {
+    const section = makeSection("12345");
+    const responseBody = makeFacultyResponse("12345", TERM, [
+      {
+        displayName: "John Smith",
+        emailAddress: "j.smith@northeastern.edu",
+        primaryIndicator: true,
+      },
+    ]);
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=12345`,
+      )
+      .reply(200, responseBody);
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(section.faculty.length, 1);
+    assert.equal(section.faculty[0].displayName, "John Smith");
+    assert.equal(section.faculty[0].email, "j.smith@northeastern.edu");
+    assert.equal(section.faculty[0].primary, true);
+  });
+
+  test("handles HTML entities in faculty names (double decode)", async () => {
+    const section = makeSection("12345");
+    // Double-encoded ampersand: &amp;amp; -> first decode -> &amp; -> second decode -> &
+    const responseBody = makeFacultyResponse("12345", TERM, [
+      {
+        displayName: "O&amp;amp;Brien",
+        emailAddress: null,
+        primaryIndicator: false,
+      },
+    ]);
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=12345`,
+      )
+      .reply(200, responseBody);
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(section.faculty[0].displayName, "O&Brien");
+    assert.equal(section.faculty[0].email, null);
+    assert.equal(section.faculty[0].primary, false);
+  });
+
+  test("returns failed CRNs array on fetch failure", async () => {
+    const section = makeSection("99999");
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=99999`,
+      )
+      .replyWithError("connection refused");
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, ["99999", "99999"]);
+    assert.deepEqual(section.faculty, []);
+  });
+
+  test("returns failed CRNs on parse failure", async () => {
+    const section = makeSection("88888");
+
+    // Return an object that does not match the expected schema (missing "fmt" key)
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=88888`,
+      )
+      .reply(200, { invalid: "data" });
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section],
+    );
+
+    assert.deepEqual(failed, ["88888"]);
+    assert.deepEqual(section.faculty, []);
+  });
+
+  test("emits fetch:error event on fetch failure", async () => {
+    const section = makeSection("77777");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=77777`,
+      )
+      .replyWithError("timeout");
+
+    await scrapeMeetingsFaculty(makeFe(), TERM, [section], emitter);
+
+    assert.equal(errors.length, 2);
+    assert.equal(errors[0].crn, "77777");
+    assert.equal(errors[0].step, "faculty");
+    assert.ok(errors[0].message.includes("timeout"));
+  });
+
+  test("emits fetch:error event on parse failure", async () => {
+    const section = makeSection("66666");
+    const emitter = new ScraperEventEmitter();
+    const errors: { crn?: string; step?: string; message: string }[] = [];
+
+    emitter.on("fetch:error", (data) => {
+      errors.push(data);
+    });
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=66666`,
+      )
+      .reply(200, { notFmt: [] });
+
+    await scrapeMeetingsFaculty(makeFe(), TERM, [section], emitter);
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].crn, "66666");
+    assert.equal(errors[0].step, "faculty");
+  });
+
+  test("processes multiple sections", async () => {
+    const section1 = makeSection("11111");
+    const section2 = makeSection("22222");
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=11111`,
+      )
+      .reply(
+        200,
+        makeFacultyResponse("11111", TERM, [
+          {
+            displayName: "Alice",
+            emailAddress: "alice@neu.edu",
+            primaryIndicator: true,
+          },
+        ]),
+      );
+
+    nock(BASE_URL)
+      .get(
+        `/StudentRegistrationSsb/ssb/searchResults/getFacultyMeetingTimes?term=${TERM}&courseReferenceNumber=22222`,
+      )
+      .reply(
+        200,
+        makeFacultyResponse("22222", TERM, [
+          {
+            displayName: "Bob",
+            emailAddress: "bob@neu.edu",
+            primaryIndicator: false,
+          },
+        ]),
+      );
+
+    const failed = await scrapeMeetingsFaculty(
+      makeFe(),
+      TERM,
+      [section1, section2],
+    );
+
+    assert.deepEqual(failed, []);
+    assert.equal(section1.faculty[0].displayName, "Alice");
+    assert.equal(section2.faculty[0].displayName, "Bob");
+  });
+});

--- a/packages/scraper/src/generate/steps/reqs.test.ts
+++ b/packages/scraper/src/generate/steps/reqs.test.ts
@@ -1,0 +1,416 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { parsePrereqs, parseCoreqs, populatePostReqs } from "./reqs";
+import type { Course, Condition, ReqsCourse, Test } from "../../types";
+
+const subjects = [
+  { code: "CS", description: "Computer Science" },
+  { code: "MATH", description: "Mathematics" },
+  { code: "PHYS", description: "Physics" },
+  { code: "ENGW", description: "English Writing" },
+];
+
+/**
+ * Build a prereq-style HTML table. Each row has 9 columns:
+ *   [0] And/Or, [1] open paren, [2] test name, [3] test score,
+ *   [4] subject name, [5] course number, [6] unused, [7] unused, [8] close paren
+ */
+function prereqRow(
+  andOr: string,
+  open: string,
+  testName: string,
+  testScore: string,
+  subjectName: string,
+  courseNumber: string,
+  close: string,
+): string {
+  return `<tr><td>${andOr}</td><td>${open}</td><td>${testName}</td><td>${testScore}</td><td>${subjectName}</td><td>${courseNumber}</td><td> </td><td> </td><td>${close}</td></tr>`;
+}
+
+function wrapTable(rows: string): string {
+  return `<table><tbody>${rows}</tbody></table>`;
+}
+
+// Helper: build a coreq row with 3 columns (no condition prefix)
+function coreq3ColRow(subjectName: string, courseNumber: string): string {
+  return `<tr><td>${subjectName}</td><td>${courseNumber}</td><td> </td></tr>`;
+}
+
+// Helper: build a coreq row with 4 columns (with condition prefix)
+function coreq4ColRow(
+  condition: string,
+  subjectName: string,
+  courseNumber: string,
+): string {
+  return `<tr><td>${condition}</td><td>${subjectName}</td><td>${courseNumber}</td><td> </td></tr>`;
+}
+
+/** Create a minimal Course object for testing populatePostReqs. */
+function makeCourse(
+  subject: string,
+  courseNumber: string,
+  prereqs: Course["prereqs"],
+): Course {
+  return {
+    subject,
+    courseNumber,
+    specialTopics: false,
+    name: `${subject} ${courseNumber}`,
+    description: "",
+    maxCredits: 4,
+    minCredits: 4,
+    attributes: [],
+    coreqs: {},
+    prereqs,
+    postreqs: {},
+  };
+}
+
+// ---------- parsePrereqs ----------
+
+describe("parsePrereqs", () => {
+  test("returns empty object when HTML has no tbody", () => {
+    const result = parsePrereqs("<table></table>", subjects);
+    assert.deepEqual(result, {});
+  });
+
+  test("returns empty object for empty string", () => {
+    const result = parsePrereqs("", subjects);
+    assert.deepEqual(result, {});
+  });
+
+  test("extracts single course prerequisite", () => {
+    const html = wrapTable(
+      prereqRow(" ", " ", " ", " ", "Computer Science", "2500", " "),
+    );
+    const result = parsePrereqs(html, subjects);
+    assert.deepEqual(result, { subject: "CS", courseNumber: "2500" });
+  });
+
+  test("extracts AND conditions between courses", () => {
+    const rows =
+      prereqRow(" ", " ", " ", " ", "Computer Science", "2500", " ") +
+      prereqRow("And", " ", " ", " ", "Mathematics", "1341", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects) as Condition;
+    assert.equal(result.type, "and");
+    assert.equal(result.items.length, 2);
+    assert.deepEqual(result.items[0], {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.deepEqual(result.items[1], {
+      subject: "MATH",
+      courseNumber: "1341",
+    });
+  });
+
+  test("extracts OR conditions between courses", () => {
+    const rows =
+      prereqRow(" ", " ", " ", " ", "Computer Science", "2500", " ") +
+      prereqRow("Or", " ", " ", " ", "Computer Science", "2510", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects) as Condition;
+    assert.equal(result.type, "or");
+    assert.equal(result.items.length, 2);
+    assert.deepEqual(result.items[0], {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.deepEqual(result.items[1], {
+      subject: "CS",
+      courseNumber: "2510",
+    });
+  });
+
+  test("handles nested conditions with parentheses (stack-based parsing)", () => {
+    // (CS 2500 OR CS 2510) AND MATH 1341
+    const rows =
+      prereqRow(" ", "(", " ", " ", "Computer Science", "2500", " ") +
+      prereqRow("Or", " ", " ", " ", "Computer Science", "2510", ")") +
+      prereqRow("And", " ", " ", " ", "Mathematics", "1341", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects) as Condition;
+    assert.equal(result.type, "and");
+    assert.equal(result.items.length, 2);
+
+    const nested = result.items[0] as Condition;
+    assert.equal(nested.type, "or");
+    assert.equal(nested.items.length, 2);
+    assert.deepEqual(nested.items[0], {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.deepEqual(nested.items[1], {
+      subject: "CS",
+      courseNumber: "2510",
+    });
+    assert.deepEqual(result.items[1], {
+      subject: "MATH",
+      courseNumber: "1341",
+    });
+  });
+
+  test("extracts test score prerequisites", () => {
+    const html = wrapTable(
+      prereqRow(" ", " ", "SAT Mathematics", "600", " ", " ", " "),
+    );
+    const result = parsePrereqs(html, subjects) as Test;
+    assert.equal(result.name, "SAT Mathematics");
+    assert.equal(result.score, 600);
+  });
+
+  test("handles mixed courses and tests in conditions", () => {
+    const rows =
+      prereqRow(" ", " ", " ", " ", "Computer Science", "1800", " ") +
+      prereqRow("Or", " ", "AP Computer Science", "4", " ", " ", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects) as Condition;
+    assert.equal(result.type, "or");
+    assert.equal(result.items.length, 2);
+    assert.deepEqual(result.items[0], {
+      subject: "CS",
+      courseNumber: "1800",
+    });
+    assert.deepEqual(result.items[1], {
+      name: "AP Computer Science",
+      score: 4,
+    });
+  });
+
+  test("returns '??' for unknown subject name", () => {
+    const html = wrapTable(
+      prereqRow(" ", " ", " ", " ", "Underwater Basket Weaving", "1000", " "),
+    );
+    const result = parsePrereqs(html, subjects) as ReqsCourse;
+    assert.equal(result.subject, "??");
+    assert.equal(result.courseNumber, "1000");
+  });
+
+  test("condition merging: same-type nested conditions get flattened", () => {
+    // (CS 2500 OR CS 2510) OR CS 3500
+    // The inner OR should be merged into the outer OR
+    const rows =
+      prereqRow(" ", "(", " ", " ", "Computer Science", "2500", " ") +
+      prereqRow("Or", " ", " ", " ", "Computer Science", "2510", ")") +
+      prereqRow("Or", " ", " ", " ", "Computer Science", "3500", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects) as Condition;
+    assert.equal(result.type, "or");
+    // After merging, all 3 courses should be in a single OR
+    assert.equal(result.items.length, 3);
+    assert.deepEqual(result.items[0], {
+      subject: "CS",
+      courseNumber: "3500",
+    });
+    assert.deepEqual(result.items[1], {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.deepEqual(result.items[2], {
+      subject: "CS",
+      courseNumber: "2510",
+    });
+  });
+
+  test("does not merge different-type nested conditions", () => {
+    // (CS 2500 AND CS 2510) OR MATH 1341
+    const rows =
+      prereqRow(" ", "(", " ", " ", "Computer Science", "2500", " ") +
+      prereqRow("And", " ", " ", " ", "Computer Science", "2510", ")") +
+      prereqRow("Or", " ", " ", " ", "Mathematics", "1341", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects) as Condition;
+    assert.equal(result.type, "or");
+    assert.equal(result.items.length, 2);
+
+    const nested = result.items[0] as Condition;
+    assert.equal(nested.type, "and");
+    assert.equal(nested.items.length, 2);
+    assert.deepEqual(result.items[1], {
+      subject: "MATH",
+      courseNumber: "1341",
+    });
+  });
+
+  test("handles tbody with rows but no course or test data", () => {
+    const rows = prereqRow(" ", " ", " ", " ", " ", " ", " ");
+    const html = wrapTable(rows);
+    const result = parsePrereqs(html, subjects);
+    assert.deepEqual(result, {});
+  });
+});
+
+// ---------- parseCoreqs ----------
+
+describe("parseCoreqs", () => {
+  test("returns empty object when HTML has no tbody", () => {
+    const result = parseCoreqs("<table></table>", subjects);
+    assert.deepEqual(result, {});
+  });
+
+  test("returns empty object for empty string", () => {
+    const result = parseCoreqs("", subjects);
+    assert.deepEqual(result, {});
+  });
+
+  test("extracts single corequisite course (3-column row)", () => {
+    const html = wrapTable(coreq3ColRow("Computer Science", "2510"));
+    const result = parseCoreqs(html, subjects);
+    assert.deepEqual(result, { subject: "CS", courseNumber: "2510" });
+  });
+
+  test("wraps multiple corequisites in AND condition (3-column rows)", () => {
+    const rows =
+      coreq3ColRow("Computer Science", "2510") +
+      coreq3ColRow("Mathematics", "1341");
+    const html = wrapTable(rows);
+    const result = parseCoreqs(html, subjects) as Condition;
+    assert.equal(result.type, "and");
+    assert.equal(result.items.length, 2);
+    assert.deepEqual(result.items[0], {
+      subject: "CS",
+      courseNumber: "2510",
+    });
+    assert.deepEqual(result.items[1], {
+      subject: "MATH",
+      courseNumber: "1341",
+    });
+  });
+
+  test("handles 4-column rows with condition prefix", () => {
+    const rows =
+      coreq4ColRow(" ", "Computer Science", "2510") +
+      coreq4ColRow("And", "Physics", "1151");
+    const html = wrapTable(rows);
+    const result = parseCoreqs(html, subjects) as Condition;
+    assert.equal(result.type, "and");
+    assert.equal(result.items.length, 2);
+    assert.deepEqual(result.items[0], {
+      subject: "CS",
+      courseNumber: "2510",
+    });
+    assert.deepEqual(result.items[1], {
+      subject: "PHYS",
+      courseNumber: "1151",
+    });
+  });
+
+  test("returns '??' for unknown subject name in coreqs", () => {
+    const html = wrapTable(coreq3ColRow("Marine Biology", "1000"));
+    const result = parseCoreqs(html, subjects) as ReqsCourse;
+    assert.equal(result.subject, "??");
+    assert.equal(result.courseNumber, "1000");
+  });
+});
+
+// ---------- populatePostReqs ----------
+
+describe("populatePostReqs", () => {
+  test("empty courses array: no-op", () => {
+    const courses: Course[] = [];
+    populatePostReqs(courses);
+    assert.equal(courses.length, 0);
+  });
+
+  test("single prereq chain: A requires B, B gets postreq A", () => {
+    const courseB = makeCourse("CS", "2500", {});
+    const courseA = makeCourse("CS", "3500", {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    const courses = [courseA, courseB];
+    populatePostReqs(courses);
+
+    const bPostReqs = courseB.postreqs as Condition;
+    assert.equal(bPostReqs.type, "and");
+    assert.equal(bPostReqs.items.length, 1);
+    assert.deepEqual(bPostReqs.items[0], {
+      subject: "CS",
+      courseNumber: "3500",
+    });
+  });
+
+  test("multiple courses sharing the same prereq", () => {
+    const prereqCourse = makeCourse("CS", "2500", {});
+    const courseA = makeCourse("CS", "3500", {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    const courseB = makeCourse("CS", "3800", {
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    const courses = [courseA, courseB, prereqCourse];
+    populatePostReqs(courses);
+
+    const postreqs = prereqCourse.postreqs as Condition;
+    assert.equal(postreqs.type, "and");
+    assert.equal(postreqs.items.length, 2);
+
+    const postreqKeys = postreqs.items.map((item) => {
+      const course = item as ReqsCourse;
+      return `${course.subject} ${course.courseNumber}`;
+    });
+    assert.ok(postreqKeys.includes("CS 3500"));
+    assert.ok(postreqKeys.includes("CS 3800"));
+  });
+
+  test("nested prereqs (OR/AND conditions) — all leaf courses become postreq sources", () => {
+    const cs2500 = makeCourse("CS", "2500", {});
+    const cs2510 = makeCourse("CS", "2510", {});
+    const math1341 = makeCourse("MATH", "1341", {});
+
+    // CS 3500 requires (CS 2500 OR CS 2510) AND MATH 1341
+    const cs3500 = makeCourse("CS", "3500", {
+      type: "and",
+      items: [
+        {
+          type: "or",
+          items: [
+            { subject: "CS", courseNumber: "2500" },
+            { subject: "CS", courseNumber: "2510" },
+          ],
+        },
+        { subject: "MATH", courseNumber: "1341" },
+      ],
+    });
+
+    const courses = [cs2500, cs2510, math1341, cs3500];
+    populatePostReqs(courses);
+
+    // CS 2500 should list CS 3500 as postreq
+    const cs2500Post = cs2500.postreqs as Condition;
+    assert.equal(cs2500Post.type, "and");
+    assert.deepEqual(cs2500Post.items[0], {
+      subject: "CS",
+      courseNumber: "3500",
+    });
+
+    // CS 2510 should also list CS 3500 as postreq
+    const cs2510Post = cs2510.postreqs as Condition;
+    assert.equal(cs2510Post.type, "and");
+    assert.deepEqual(cs2510Post.items[0], {
+      subject: "CS",
+      courseNumber: "3500",
+    });
+
+    // MATH 1341 should also list CS 3500 as postreq
+    const math1341Post = math1341.postreqs as Condition;
+    assert.equal(math1341Post.type, "and");
+    assert.deepEqual(math1341Post.items[0], {
+      subject: "CS",
+      courseNumber: "3500",
+    });
+  });
+
+  test("course with no prereqs gets empty postreqs", () => {
+    const courseA = makeCourse("CS", "1200", {});
+    const courseB = makeCourse("CS", "1800", {});
+    const courses = [courseA, courseB];
+    populatePostReqs(courses);
+
+    assert.deepEqual(courseA.postreqs, {});
+    assert.deepEqual(courseB.postreqs, {});
+  });
+});

--- a/packages/scraper/src/generate/steps/sections.test.ts
+++ b/packages/scraper/src/generate/steps/sections.test.ts
@@ -1,0 +1,302 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { scrapeSections } from "./sections";
+import { ScraperEventEmitter } from "../../events";
+
+const BASE = "https://nubanner.neu.edu";
+const AUTH_PATH = "/StudentRegistrationSsb/ssb/term/search";
+const SEARCH_PATH =
+  "/StudentRegistrationSsb/ssb/searchResults/searchResults";
+
+/** Build a minimal BannerSection object that passes the strict Zod schema. */
+function makeBannerSection(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    term: "202510",
+    termDesc: "Spring 2025",
+    courseReferenceNumber: "12345",
+    partOfTerm: "1",
+    courseNumber: "2500",
+    subject: "CS",
+    subjectDescription: "Computer Science",
+    sequenceNumber: "01",
+    campusDescription: "Boston",
+    scheduleTypeDescription: "Lecture",
+    courseTitle: "Fundamentals of Computer Science 1",
+    creditHours: null,
+    maximumEnrollment: 100,
+    enrollment: 50,
+    seatsAvailable: 50,
+    waitCapacity: 0,
+    waitCount: 0,
+    waitAvailable: 0,
+    crossList: null,
+    crossListCapacity: null,
+    crossListCount: null,
+    crossListAvailable: null,
+    creditHourHigh: null,
+    creditHourLow: 4,
+    creditHourIndicator: null,
+    openSection: true,
+    linkIdentifier: null,
+    isSectionLinked: false,
+    subjectCourse: "CS2500",
+    faculty: [],
+    meetingsFaculty: [
+      {
+        category: "01",
+        class: "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+        courseReferenceNumber: "12345",
+        faculty: [
+          {
+            bannerId: "000111222",
+            category: "01",
+            class:
+              "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+            courseReferenceNumber: "12345",
+            displayName: "Test Instructor",
+            emailAddress: null,
+            primaryIndicator: true,
+            term: "202510",
+          },
+        ],
+        meetingTime: {
+          beginTime: "0935",
+          building: "WVH",
+          buildingDescription: "West Village H",
+          campus: "BOS",
+          campusDescription: "Boston",
+          category: "01",
+          class:
+            "net.hedtech.banner.student.schedule.SectionSessionDecorator",
+          courseReferenceNumber: "12345",
+          creditHourSession: 4,
+          endDate: "04/14/2025",
+          endTime: "1040",
+          friday: false,
+          hoursWeek: 2.16,
+          meetingScheduleType: "LEC",
+          meetingType: "CLAS",
+          meetingTypeDescription: "Class",
+          monday: true,
+          room: "210",
+          saturday: false,
+          startDate: "01/06/2025",
+          sunday: false,
+          term: "202510",
+          thursday: false,
+          tuesday: false,
+          wednesday: true,
+        },
+        term: "202510",
+      },
+    ],
+    reservedSeatSummary: null,
+    sectionAttributes: [
+      {
+        class:
+          "net.hedtech.banner.student.schedule.SectionDecorator",
+        code: "NUCS",
+        courseReferenceNumber: "12345",
+        description: "NUpath Creative Express/Mail",
+        isZTCAttribute: false,
+        termCode: "202510",
+      },
+    ],
+    instructionalMethod: null,
+    instructionalMethodDescription: null,
+    ...overrides,
+  };
+}
+
+/** Build a valid BannerSectionResponse envelope. */
+function makeSectionResponse(
+  data: unknown[],
+  totalCount: number,
+  pageOffset = 0,
+  pageMaxSize = 500,
+) {
+  return {
+    success: true,
+    totalCount,
+    data,
+    pageOffset,
+    pageMaxSize,
+    sectionsFetchedCount: data.length,
+    pathMode: null,
+    searchResultsConfigs: [
+      {
+        config: "term",
+        display: "Term",
+        title: "Term",
+        required: true,
+        width: "200",
+      },
+    ],
+    ztcEncodedImage: "",
+  };
+}
+
+/**
+ * Set up nock interceptors to mock `count` auth-cookie POST requests.
+ * Each returns a unique JSESSIONID cookie.
+ */
+function mockAuthCookies(count: number) {
+  for (let i = 0; i < count; i++) {
+    nock(BASE)
+      .post(AUTH_PATH)
+      .reply(200, "", {
+        "Set-Cookie": [`JSESSIONID=cookie${i}; Path=/`],
+      });
+  }
+}
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("scrapeSections", () => {
+  test("successful scrape with a small number of sections", async () => {
+    const term = "202510";
+    const section = makeBannerSection();
+    mockAuthCookies(2);
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "1",
+      })
+      .reply(200, makeSectionResponse([section], 1, 0, 1));
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "500",
+      })
+      .reply(200, makeSectionResponse([section], 1, 0, 500));
+
+    const result = await scrapeSections(term, undefined, 1);
+    assert.ok(result);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].courseReferenceNumber, "12345");
+  });
+
+  test("returns undefined when no auth cookies available", async () => {
+    const term = "202510";
+
+    // Both auth requests fail so allSettled yields zero cookies
+    nock(BASE).post(AUTH_PATH).replyWithError("connection refused");
+    nock(BASE).post(AUTH_PATH).replyWithError("connection refused");
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { message: string }[] = [];
+    emitter.on("error", (data) => errors.push(data));
+
+    const result = await scrapeSections(term, emitter, 1);
+    assert.equal(result, undefined);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].message, "not enough banner auth cookies");
+  });
+
+  test("returns undefined when initial section response fails to parse", async () => {
+    const term = "202510";
+    mockAuthCookies(2);
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "1",
+      })
+      .reply(200, { invalid: true });
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { message: string }[] = [];
+    emitter.on("error", (data) => errors.push(data));
+
+    const result = await scrapeSections(term, emitter, 1);
+    assert.equal(result, undefined);
+    assert.equal(errors.length, 1);
+    assert.match(
+      errors[0].message,
+      /error parsing initial section response/,
+    );
+  });
+
+  test("section count mismatch emits warning", async () => {
+    const term = "202510";
+    const section = makeBannerSection();
+    mockAuthCookies(2);
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "1",
+      })
+      .reply(200, makeSectionResponse([section], 2, 0, 1));
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "500",
+      })
+      .reply(200, makeSectionResponse([section], 2, 0, 500));
+
+    const emitter = new ScraperEventEmitter();
+    const warnings: { message: string }[] = [];
+    emitter.on("warn", (data) => warnings.push(data));
+
+    const result = await scrapeSections(term, emitter, 1);
+    assert.ok(result);
+    assert.equal(result.length, 1);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /section count mismatch/);
+  });
+
+  test("emitter events are fired correctly", async () => {
+    const term = "202510";
+    const section = makeBannerSection();
+    mockAuthCookies(2);
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "1",
+      })
+      .reply(200, makeSectionResponse([section], 1, 0, 1));
+
+    nock(BASE)
+      .get(SEARCH_PATH)
+      .query({
+        txt_term: term,
+        pageOffset: "0",
+        pageMaxSize: "500",
+      })
+      .reply(200, makeSectionResponse([section], 1, 0, 500));
+
+    const emitter = new ScraperEventEmitter();
+    const events: string[] = [];
+
+    emitter.on("scrape:sections:start", () => events.push("start"));
+    emitter.on("scrape:sections:done", () => events.push("done"));
+    emitter.on("debug", () => events.push("debug"));
+
+    const result = await scrapeSections(term, emitter, 1);
+    assert.ok(result);
+    assert.ok(events.includes("start"));
+    assert.ok(events.includes("done"));
+    assert.ok(events.includes("debug"));
+  });
+});

--- a/packages/scraper/src/generate/steps/terms.test.ts
+++ b/packages/scraper/src/generate/steps/terms.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import nock from "nock";
+import { scrapeTermDefinition } from "./terms";
+import { ScraperEventEmitter } from "../../events";
+
+const BASE = "https://nubanner.neu.edu";
+const TERMS_PATH =
+  "/StudentRegistrationSsb/ssb/classSearch/getTerms";
+
+afterEach(() => {
+  nock.cleanAll();
+});
+
+describe("scrapeTermDefinition", () => {
+  test("returns matching term object on success", async () => {
+    nock(BASE)
+      .get(TERMS_PATH)
+      .query({ offset: "1", max: "10", searchTerm: "202510" })
+      .reply(200, [
+        { code: "202510", description: "Spring 2025" },
+        { code: "202530", description: "Summer 2025" },
+      ]);
+
+    const result = await scrapeTermDefinition("202510");
+    assert.deepStrictEqual(result, {
+      code: "202510",
+      description: "Spring 2025",
+    });
+  });
+
+  test("returns undefined and emits error when no matching term found", async () => {
+    nock(BASE)
+      .get(TERMS_PATH)
+      .query({ offset: "1", max: "10", searchTerm: "202510" })
+      .reply(200, [{ code: "202530", description: "Summer 2025" }]);
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { message: string }[] = [];
+    emitter.on("error", (data) => errors.push(data));
+
+    const result = await scrapeTermDefinition("202510", emitter);
+    assert.equal(result, undefined);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].message, "cannot find term in Banner");
+  });
+
+  test("returns undefined and emits error when multiple matching terms found", async () => {
+    nock(BASE)
+      .get(TERMS_PATH)
+      .query({ offset: "1", max: "10", searchTerm: "202510" })
+      .reply(200, [
+        { code: "202510", description: "Spring 2025" },
+        { code: "202510", description: "Spring 2025 (View Only)" },
+      ]);
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { message: string }[] = [];
+    emitter.on("error", (data) => errors.push(data));
+
+    const result = await scrapeTermDefinition("202510", emitter);
+    assert.equal(result, undefined);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].message, "multiple matching terms found");
+  });
+
+  test("returns undefined and emits error on parse failure", async () => {
+    nock(BASE)
+      .get(TERMS_PATH)
+      .query({ offset: "1", max: "10", searchTerm: "202510" })
+      .reply(200, { unexpected: "format" });
+
+    const emitter = new ScraperEventEmitter();
+    const errors: { message: string }[] = [];
+    emitter.on("error", (data) => errors.push(data));
+
+    const result = await scrapeTermDefinition("202510", emitter);
+    assert.equal(result, undefined);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].message, "error parsing banner term info");
+  });
+});

--- a/packages/scraper/src/schemas/banner/campuses.test.ts
+++ b/packages/scraper/src/schemas/banner/campuses.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerCampuses, BannerCampusesResponse } from "./campuses";
+
+describe("BannerCampuses", () => {
+  test("accepts a valid campus with a 3-character code", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOS",
+      description: "Boston",
+    });
+    assert.ok(result.success);
+  });
+
+  test("rejects a code shorter than 3 characters", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BO",
+      description: "Boston",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects a code longer than 3 characters", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOST",
+      description: "Boston",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects missing description", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOS",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = BannerCampuses.safeParse({
+      code: "BOS",
+      description: "Boston",
+      extra: "field",
+    });
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerCampusesResponse", () => {
+  test("accepts an array of valid campuses", () => {
+    const result = BannerCampusesResponse.safeParse([
+      { code: "BOS", description: "Boston" },
+      { code: "OAK", description: "Oakland" },
+    ]);
+    assert.ok(result.success);
+  });
+
+  test("accepts an empty array", () => {
+    const result = BannerCampusesResponse.safeParse([]);
+    assert.ok(result.success);
+  });
+
+  test("rejects if any campus in the array is invalid", () => {
+    const result = BannerCampusesResponse.safeParse([
+      { code: "BOS", description: "Boston" },
+      { code: "TOOLONG", description: "Invalid" },
+    ]);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/common.test.ts
+++ b/packages/scraper/src/schemas/banner/common.test.ts
@@ -1,0 +1,57 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerTerm, BannerCRN } from "./common";
+
+describe("BannerTerm", () => {
+  test("accepts a 6-character string", () => {
+    const result = BannerTerm.safeParse("202610");
+    assert.ok(result.success);
+  });
+
+  test("rejects a string shorter than 6 characters", () => {
+    const result = BannerTerm.safeParse("20261");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a string longer than 6 characters", () => {
+    const result = BannerTerm.safeParse("2026100");
+    assert.ok(!result.success);
+  });
+
+  test("rejects an empty string", () => {
+    const result = BannerTerm.safeParse("");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a non-string value", () => {
+    const result = BannerTerm.safeParse(202610);
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerCRN", () => {
+  test("accepts a 5-character string", () => {
+    const result = BannerCRN.safeParse("12345");
+    assert.ok(result.success);
+  });
+
+  test("rejects a string shorter than 5 characters", () => {
+    const result = BannerCRN.safeParse("1234");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a string longer than 5 characters", () => {
+    const result = BannerCRN.safeParse("123456");
+    assert.ok(!result.success);
+  });
+
+  test("rejects an empty string", () => {
+    const result = BannerCRN.safeParse("");
+    assert.ok(!result.success);
+  });
+
+  test("rejects a non-string value", () => {
+    const result = BannerCRN.safeParse(12345);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/meetingsFaculty.test.ts
+++ b/packages/scraper/src/schemas/banner/meetingsFaculty.test.ts
@@ -1,0 +1,194 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BannerSectionMeetingsFaculty,
+  BannerSectionMeetingsFacultyResponse,
+} from "./meetingsFaculty";
+
+function validMeetingTime() {
+  return {
+    beginTime: "0935",
+    building: "RI",
+    buildingDescription: "Richards Hall",
+    campus: "BOS",
+    campusDescription: "Boston",
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingTime",
+    courseReferenceNumber: "12345",
+    creditHourSession: 4,
+    endDate: "04/13/2026",
+    endTime: "1015",
+    friday: false,
+    hoursWeek: 1.33,
+    meetingScheduleType: "LEC",
+    meetingType: "CLAS",
+    meetingTypeDescription: "Class",
+    monday: true,
+    room: "300",
+    saturday: false,
+    startDate: "01/12/2026",
+    sunday: false,
+    term: "202630",
+    thursday: false,
+    tuesday: false,
+    wednesday: true,
+  };
+}
+
+function validFacultyItem() {
+  return {
+    bannerId: "001234567",
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionFaculty",
+    courseReferenceNumber: "12345",
+    displayName: "Smith, John",
+    emailAddress: "j.smith@northeastern.edu",
+    primaryIndicator: true,
+    term: "202630",
+  };
+}
+
+function validMeetingsFaculty() {
+  return {
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingFaculty",
+    courseReferenceNumber: "12345",
+    faculty: [validFacultyItem()],
+    meetingTime: validMeetingTime(),
+    term: "202630",
+  };
+}
+
+describe("BannerSectionMeetingsFaculty", () => {
+  test("accepts a valid object with faculty and meetingTime", () => {
+    const result = BannerSectionMeetingsFaculty.safeParse(
+      validMeetingsFaculty(),
+    );
+    assert.ok(result.success);
+  });
+
+  test("accepts an empty faculty array", () => {
+    const data = validMeetingsFaculty();
+    data.faculty = [];
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable emailAddress in faculty", () => {
+    const data = validMeetingsFaculty();
+    data.faculty = [{ ...validFacultyItem(), emailAddress: null }];
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable beginTime and endTime", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = {
+      ...validMeetingTime(),
+      beginTime: null,
+      endTime: null,
+    };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable building and room", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = {
+      ...validMeetingTime(),
+      building: null,
+      buildingDescription: null,
+      room: null,
+    };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable campus fields", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = {
+      ...validMeetingTime(),
+      campus: null,
+      campusDescription: null,
+    };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("accepts nullable creditHourSession", () => {
+    const data = validMeetingsFaculty();
+    data.meetingTime = { ...validMeetingTime(), creditHourSession: null };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("rejects invalid courseReferenceNumber (wrong length)", () => {
+    const data = validMeetingsFaculty();
+    data.courseReferenceNumber = "123";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects invalid term (wrong length)", () => {
+    const data = validMeetingsFaculty();
+    data.term = "20";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields on the top-level object (strictObject)", () => {
+    const data = { ...validMeetingsFaculty(), extra: "field" };
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields on meetingTime (strictObject)", () => {
+    const data = validMeetingsFaculty();
+    (data.meetingTime as Record<string, unknown>).extra = "field";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields on faculty item (strictObject)", () => {
+    const data = validMeetingsFaculty();
+    data.faculty = [{ ...validFacultyItem(), extra: "field" } as never];
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates all day-of-week booleans in meetingTime", () => {
+    const data = validMeetingsFaculty();
+    (data.meetingTime as Record<string, unknown>).monday = "yes";
+    const result = BannerSectionMeetingsFaculty.safeParse(data);
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerSectionMeetingsFacultyResponse", () => {
+  test("accepts a valid response with fmt array", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({
+      fmt: [validMeetingsFaculty()],
+    });
+    assert.ok(result.success);
+  });
+
+  test("accepts a response with empty fmt array", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({
+      fmt: [],
+    });
+    assert.ok(result.success);
+  });
+
+  test("rejects missing fmt field", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({});
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = BannerSectionMeetingsFacultyResponse.safeParse({
+      fmt: [],
+      extra: "field",
+    });
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/section.test.ts
+++ b/packages/scraper/src/schemas/banner/section.test.ts
@@ -1,0 +1,332 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerSection, BannerSectionResponse } from "./section";
+
+function validMeetingTime() {
+  return {
+    beginTime: "0935",
+    building: "RI",
+    buildingDescription: "Richards Hall",
+    campus: "BOS",
+    campusDescription: "Boston",
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingTime",
+    courseReferenceNumber: "12345",
+    creditHourSession: 4,
+    endDate: "04/13/2026",
+    endTime: "1015",
+    friday: false,
+    hoursWeek: 1.33,
+    meetingScheduleType: "LEC",
+    meetingType: "CLAS",
+    meetingTypeDescription: "Class",
+    monday: true,
+    room: "300",
+    saturday: false,
+    startDate: "01/12/2026",
+    sunday: false,
+    term: "202630",
+    thursday: false,
+    tuesday: false,
+    wednesday: true,
+  };
+}
+
+function validMeetingsFacultyItem() {
+  return {
+    category: "01",
+    class: "net.hedtech.banner.student.schedule.SectionSessionMeetingFaculty",
+    courseReferenceNumber: "12345",
+    faculty: [
+      {
+        bannerId: "001234567",
+        category: "01",
+        class: "net.hedtech.banner.student.schedule.SectionSessionFaculty",
+        courseReferenceNumber: "12345",
+        displayName: "Smith, John",
+        emailAddress: "j.smith@northeastern.edu",
+        primaryIndicator: true,
+        term: "202630",
+      },
+    ],
+    meetingTime: validMeetingTime(),
+    term: "202630",
+  };
+}
+
+function validSectionAttribute() {
+  return {
+    class: "net.hedtech.banner.student.schedule.SectionSessionAttribute",
+    code: "UBOS",
+    courseReferenceNumber: "12345",
+    description: "Boston",
+    isZTCAttribute: false,
+    termCode: "202630",
+  };
+}
+
+function validSection() {
+  return {
+    id: 1,
+    term: "202630",
+    termDesc: "Spring 2026 (View Only)",
+    courseReferenceNumber: "12345",
+    partOfTerm: "1",
+    courseNumber: "2500",
+    subject: "CS",
+    subjectDescription: "Computer Science",
+    sequenceNumber: "01",
+    campusDescription: "Boston",
+    scheduleTypeDescription: "Lecture",
+    courseTitle: "Fundamentals of Computer Science 1",
+    creditHours: null,
+    maximumEnrollment: 100,
+    enrollment: 95,
+    seatsAvailable: 5,
+    waitCapacity: 10,
+    waitCount: 3,
+    waitAvailable: 7,
+    crossList: null,
+    crossListCapacity: null,
+    crossListCount: null,
+    crossListAvailable: null,
+    creditHourHigh: null,
+    creditHourLow: 4,
+    creditHourIndicator: null,
+    openSection: true,
+    linkIdentifier: null,
+    isSectionLinked: false,
+    subjectCourse: "CS2500",
+    faculty: [],
+    meetingsFaculty: [validMeetingsFacultyItem()],
+    reservedSeatSummary: null,
+    sectionAttributes: [validSectionAttribute()],
+    instructionalMethod: null,
+    instructionalMethodDescription: null,
+  };
+}
+
+function validSectionResponse() {
+  return {
+    success: true,
+    totalCount: 1,
+    data: [validSection()],
+    pageOffset: 0,
+    pageMaxSize: 500,
+    sectionsFetchedCount: 1,
+    pathMode: null,
+    searchResultsConfigs: [
+      {
+        config: "config1",
+        display: "display1",
+        title: "Title",
+        required: true,
+        width: "100",
+      },
+    ],
+    ztcEncodedImage: "data:image/png;base64,...",
+  };
+}
+
+describe("BannerSection", () => {
+  test("accepts a valid section with all required fields", () => {
+    const result = BannerSection.safeParse(validSection());
+    assert.ok(result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const data = { ...validSection(), extra: "field" };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates nested meetingsFaculty array", () => {
+    const data = validSection();
+    data.meetingsFaculty = [{ invalid: true } as never];
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates nested sectionAttributes array", () => {
+    const data = validSection();
+    data.sectionAttributes = [{ invalid: true } as never];
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("courseNumber must be exactly 4 characters", () => {
+    const tooShort = { ...validSection(), courseNumber: "250" };
+    assert.ok(!BannerSection.safeParse(tooShort).success);
+
+    const tooLong = { ...validSection(), courseNumber: "25000" };
+    assert.ok(!BannerSection.safeParse(tooLong).success);
+
+    const exact = { ...validSection(), courseNumber: "2500" };
+    assert.ok(BannerSection.safeParse(exact).success);
+  });
+
+  test("courseReferenceNumber must be exactly 5 characters (BannerCRN)", () => {
+    const tooShort = { ...validSection(), courseReferenceNumber: "1234" };
+    assert.ok(!BannerSection.safeParse(tooShort).success);
+
+    const tooLong = { ...validSection(), courseReferenceNumber: "123456" };
+    assert.ok(!BannerSection.safeParse(tooLong).success);
+
+    const exact = { ...validSection(), courseReferenceNumber: "12345" };
+    assert.ok(BannerSection.safeParse(exact).success);
+  });
+
+  test("term must be exactly 6 characters (BannerTerm)", () => {
+    const tooShort = { ...validSection(), term: "20263" };
+    assert.ok(!BannerSection.safeParse(tooShort).success);
+
+    const tooLong = { ...validSection(), term: "2026300" };
+    assert.ok(!BannerSection.safeParse(tooLong).success);
+
+    const exact = { ...validSection(), term: "202630" };
+    assert.ok(BannerSection.safeParse(exact).success);
+  });
+
+  test("linkIdentifier must be null", () => {
+    const data = { ...validSection(), linkIdentifier: "A" };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("isSectionLinked must be false", () => {
+    const data = { ...validSection(), isSectionLinked: true };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("faculty must be an empty array (length 0)", () => {
+    const data = { ...validSection(), faculty: [null] };
+    const result = BannerSection.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("creditHours is nullable", () => {
+    const withNull = { ...validSection(), creditHours: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), creditHours: 4 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossList is nullable", () => {
+    const withNull = { ...validSection(), crossList: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossList: "XL01" };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossListCapacity is nullable", () => {
+    const withNull = { ...validSection(), crossListCapacity: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossListCapacity: 50 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossListCount is nullable", () => {
+    const withNull = { ...validSection(), crossListCount: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossListCount: 30 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("crossListAvailable is nullable", () => {
+    const withNull = { ...validSection(), crossListAvailable: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), crossListAvailable: 20 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("creditHourHigh is nullable", () => {
+    const withNull = { ...validSection(), creditHourHigh: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), creditHourHigh: 8 };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("creditHourIndicator is nullable", () => {
+    const withNull = { ...validSection(), creditHourIndicator: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = { ...validSection(), creditHourIndicator: "OR" };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("instructionalMethod is nullable", () => {
+    const withNull = { ...validSection(), instructionalMethod: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = {
+      ...validSection(),
+      instructionalMethod: "Traditional",
+    };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("instructionalMethodDescription is nullable", () => {
+    const withNull = {
+      ...validSection(),
+      instructionalMethodDescription: null,
+    };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = {
+      ...validSection(),
+      instructionalMethodDescription: "In Person",
+    };
+    assert.ok(BannerSection.safeParse(withValue).success);
+  });
+
+  test("reservedSeatSummary must be null", () => {
+    const withNull = { ...validSection(), reservedSeatSummary: null };
+    assert.ok(BannerSection.safeParse(withNull).success);
+
+    const withValue = {
+      ...validSection(),
+      reservedSeatSummary: "something",
+    };
+    assert.ok(!BannerSection.safeParse(withValue).success);
+  });
+});
+
+describe("BannerSectionResponse", () => {
+  test("accepts a valid response with data array", () => {
+    const result = BannerSectionResponse.safeParse(validSectionResponse());
+    assert.ok(result.success);
+  });
+
+  test("accepts a response with empty data array", () => {
+    const data = { ...validSectionResponse(), data: [], totalCount: 0, sectionsFetchedCount: 0 };
+    const result = BannerSectionResponse.safeParse(data);
+    assert.ok(result.success);
+  });
+
+  test("rejects missing required fields", () => {
+    const result = BannerSectionResponse.safeParse({
+      success: true,
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const data = { ...validSectionResponse(), extra: "field" };
+    const result = BannerSectionResponse.safeParse(data);
+    assert.ok(!result.success);
+  });
+
+  test("validates searchResultsConfigs entries (strictObject)", () => {
+    const data = validSectionResponse();
+    data.searchResultsConfigs = [{ config: "c", extra: true } as never];
+    const result = BannerSectionResponse.safeParse(data);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/banner/terms.test.ts
+++ b/packages/scraper/src/schemas/banner/terms.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { BannerTerms, BannerTermsResponse } from "./terms";
+
+describe("BannerTerms", () => {
+  test("accepts a valid term with a 6-character code", () => {
+    const result = BannerTerms.safeParse({
+      code: "202610",
+      description: "Spring 2026",
+    });
+    assert.ok(result.success);
+  });
+
+  test("rejects a code shorter than 6 characters", () => {
+    const result = BannerTerms.safeParse({
+      code: "20261",
+      description: "Spring 2026",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects a code longer than 6 characters", () => {
+    const result = BannerTerms.safeParse({
+      code: "2026100",
+      description: "Spring 2026",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects missing description", () => {
+    const result = BannerTerms.safeParse({
+      code: "202610",
+    });
+    assert.ok(!result.success);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = BannerTerms.safeParse({
+      code: "202610",
+      description: "Spring 2026",
+      extra: "field",
+    });
+    assert.ok(!result.success);
+  });
+});
+
+describe("BannerTermsResponse", () => {
+  test("accepts an array of valid terms", () => {
+    const result = BannerTermsResponse.safeParse([
+      { code: "202610", description: "Spring 2026" },
+      { code: "202530", description: "Fall 2025" },
+    ]);
+    assert.ok(result.success);
+  });
+
+  test("accepts an empty array", () => {
+    const result = BannerTermsResponse.safeParse([]);
+    assert.ok(result.success);
+  });
+
+  test("rejects if any term in the array is invalid", () => {
+    const result = BannerTermsResponse.safeParse([
+      { code: "202610", description: "Spring 2026" },
+      { code: "BAD", description: "Invalid" },
+    ]);
+    assert.ok(!result.success);
+  });
+});

--- a/packages/scraper/src/schemas/scraper/banner-cache.test.ts
+++ b/packages/scraper/src/schemas/scraper/banner-cache.test.ts
@@ -1,0 +1,532 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ScraperBannerCacheRequisiteTest,
+  ScraperBannerCacheRequisiteCourse,
+  ScraperBannerCacheRequisiteCondition,
+  ScraperBannerCacheRequisiteItem,
+  ScraperBannerCacheRequisite,
+  ScraperBannerFaculty,
+  ScraperBannerMeetingTime,
+  ScraperBannerCacheCourse,
+  ScraperBannerCacheSection,
+  ScraperBannerCache,
+} from "./banner-cache.js";
+
+describe("ScraperBannerCacheRequisiteTest", () => {
+  test("valid with numeric score", () => {
+    const result = ScraperBannerCacheRequisiteTest.safeParse({
+      name: "SAT Math",
+      score: 600,
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid with null score", () => {
+    const result = ScraperBannerCacheRequisiteTest.safeParse({
+      name: "SAT Math",
+      score: null,
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing name", () => {
+    const result = ScraperBannerCacheRequisiteTest.safeParse({ score: 600 });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerCacheRequisiteTest.safeParse({
+      name: "SAT Math",
+      score: 600,
+      extra: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("ScraperBannerCacheRequisiteCourse", () => {
+  test("valid course requisite", () => {
+    const result = ScraperBannerCacheRequisiteCourse.safeParse({
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing subject", () => {
+    const result = ScraperBannerCacheRequisiteCourse.safeParse({
+      courseNumber: "2500",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerCacheRequisiteCourse.safeParse({
+      subject: "CS",
+      courseNumber: "2500",
+      extra: "nope",
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("ScraperBannerCacheRequisiteCondition", () => {
+  test("valid 'and' condition with course items", () => {
+    const result = ScraperBannerCacheRequisiteCondition.safeParse({
+      type: "and",
+      items: [
+        { subject: "CS", courseNumber: "2500" },
+        { subject: "CS", courseNumber: "2510" },
+      ],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid 'or' condition with test items", () => {
+    const result = ScraperBannerCacheRequisiteCondition.safeParse({
+      type: "or",
+      items: [
+        { name: "SAT Math", score: 600 },
+        { name: "ACT Math", score: 26 },
+      ],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("recursive: condition containing conditions", () => {
+    const result = ScraperBannerCacheRequisiteCondition.safeParse({
+      type: "and",
+      items: [
+        {
+          type: "or",
+          items: [
+            { subject: "CS", courseNumber: "2500" },
+            { subject: "CS", courseNumber: "1800" },
+          ],
+        },
+        {
+          type: "or",
+          items: [
+            { name: "SAT Math", score: 600 },
+            { subject: "MATH", courseNumber: "1341" },
+          ],
+        },
+      ],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects invalid type", () => {
+    const result = ScraperBannerCacheRequisiteCondition.safeParse({
+      type: "xor",
+      items: [],
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerCacheRequisiteCondition.safeParse({
+      type: "and",
+      items: [],
+      extra: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("ScraperBannerCacheRequisiteItem", () => {
+  test("accepts course", () => {
+    const result = ScraperBannerCacheRequisiteItem.safeParse({
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("accepts test", () => {
+    const result = ScraperBannerCacheRequisiteItem.safeParse({
+      name: "SAT",
+      score: null,
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("accepts condition", () => {
+    const result = ScraperBannerCacheRequisiteItem.safeParse({
+      type: "or",
+      items: [{ subject: "CS", courseNumber: "2500" }],
+    });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("ScraperBannerCacheRequisite", () => {
+  test("accepts empty record", () => {
+    const result = ScraperBannerCacheRequisite.safeParse({});
+    assert.equal(result.success, true);
+  });
+
+  test("accepts a course requisite item", () => {
+    const result = ScraperBannerCacheRequisite.safeParse({
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("accepts a condition requisite item", () => {
+    const result = ScraperBannerCacheRequisite.safeParse({
+      type: "and",
+      items: [{ subject: "CS", courseNumber: "2500" }],
+    });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("ScraperBannerFaculty", () => {
+  test("valid faculty with email", () => {
+    const result = ScraperBannerFaculty.safeParse({
+      displayName: "John Doe",
+      email: "j.doe@northeastern.edu",
+      primary: true,
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid faculty with null email", () => {
+    const result = ScraperBannerFaculty.safeParse({
+      displayName: "Jane Doe",
+      email: null,
+      primary: false,
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing primary", () => {
+    const result = ScraperBannerFaculty.safeParse({
+      displayName: "John Doe",
+      email: null,
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerFaculty.safeParse({
+      displayName: "John Doe",
+      email: null,
+      primary: true,
+      office: "Room 101",
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("ScraperBannerMeetingTime", () => {
+  const validMeetingTime = {
+    building: "WVH",
+    buildingDescription: "West Village H",
+    room: "210",
+    campus: "BOS",
+    campusDescription: "Boston",
+    days: [1, 3, 5],
+    startTime: 800,
+    endTime: 940,
+    final: false,
+    finalDate: null,
+  };
+
+  test("valid meeting time", () => {
+    const result = ScraperBannerMeetingTime.safeParse(validMeetingTime);
+    assert.equal(result.success, true);
+  });
+
+  test("valid with all nullable fields null", () => {
+    const result = ScraperBannerMeetingTime.safeParse({
+      ...validMeetingTime,
+      building: null,
+      buildingDescription: null,
+      room: null,
+      campus: null,
+      campusDescription: null,
+      finalDate: null,
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("days array max 7 items", () => {
+    const result = ScraperBannerMeetingTime.safeParse({
+      ...validMeetingTime,
+      days: [1, 2, 3, 4, 5, 6, 7, 8],
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("days must contain integers", () => {
+    const result = ScraperBannerMeetingTime.safeParse({
+      ...validMeetingTime,
+      days: [1.5],
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerMeetingTime.safeParse({
+      ...validMeetingTime,
+      instructor: "John",
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("ScraperBannerCacheCourse", () => {
+  const validCourse = {
+    subject: "CS",
+    courseNumber: "2500",
+    specialTopics: false,
+    name: "Fundamentals of Computer Science 1",
+    description: "Intro to CS",
+    maxCredits: 4,
+    minCredits: 4,
+    attributes: ["NUpath Writing"],
+    coreqs: {},
+    prereqs: {},
+    postreqs: {},
+  };
+
+  test("valid course parses successfully", () => {
+    const result = ScraperBannerCacheCourse.safeParse(validCourse);
+    assert.equal(result.success, true);
+  });
+
+  test("valid course with optional crn", () => {
+    const result = ScraperBannerCacheCourse.safeParse({
+      ...validCourse,
+      crn: "12345",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("courseNumber must be 4 chars", () => {
+    const result = ScraperBannerCacheCourse.safeParse({
+      ...validCourse,
+      courseNumber: "250",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("courseNumber of 5 chars rejects", () => {
+    const result = ScraperBannerCacheCourse.safeParse({
+      ...validCourse,
+      courseNumber: "25000",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects missing required fields", () => {
+    const result = ScraperBannerCacheCourse.safeParse({
+      subject: "CS",
+      courseNumber: "2500",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerCacheCourse.safeParse({
+      ...validCourse,
+      level: "undergraduate",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("course with requisite items", () => {
+    const result = ScraperBannerCacheCourse.safeParse({
+      ...validCourse,
+      prereqs: {
+        type: "and",
+        items: [
+          { subject: "CS", courseNumber: "1800" },
+          { subject: "CS", courseNumber: "1802" },
+        ],
+      },
+    });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("ScraperBannerCacheSection", () => {
+  const validSection = {
+    crn: "12345",
+    name: "Fundamentals of Computer Science 1",
+    description: "Intro to CS",
+    sectionNumber: "01",
+    partOfTerm: "1",
+    seatCapacity: 100,
+    seatRemaining: 25,
+    waitlistCapacity: 10,
+    waitlistRemaining: 5,
+    classType: "Lecture",
+    honors: false,
+    campus: "BOS",
+    meetingTimes: [
+      {
+        building: "WVH",
+        buildingDescription: "West Village H",
+        room: "210",
+        campus: "BOS",
+        campusDescription: "Boston",
+        days: [1, 3, 5],
+        startTime: 800,
+        endTime: 940,
+        final: false,
+        finalDate: null,
+      },
+    ],
+    faculty: [
+      {
+        displayName: "John Doe",
+        email: "j.doe@northeastern.edu",
+        primary: true,
+      },
+    ],
+    xlist: [],
+    coreqs: {},
+    prereqs: {},
+  };
+
+  test("valid section parses successfully", () => {
+    const result = ScraperBannerCacheSection.safeParse(validSection);
+    assert.equal(result.success, true);
+  });
+
+  test("crn must be 5 chars", () => {
+    const result = ScraperBannerCacheSection.safeParse({
+      ...validSection,
+      crn: "1234",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("crn of 6 chars rejects", () => {
+    const result = ScraperBannerCacheSection.safeParse({
+      ...validSection,
+      crn: "123456",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = ScraperBannerCacheSection.safeParse({
+      ...validSection,
+      instructor: "Jane",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("xlist accepts string array", () => {
+    const result = ScraperBannerCacheSection.safeParse({
+      ...validSection,
+      xlist: ["CS 2500", "DS 2500"],
+    });
+    assert.equal(result.success, true);
+  });
+});
+
+describe("ScraperBannerCache", () => {
+  const validCache = {
+    version: 5,
+    timestamp: "2025-01-15T10:30:00Z",
+    term: { code: "202510", description: "Fall 2025" },
+    courses: [
+      {
+        subject: "CS",
+        courseNumber: "2500",
+        specialTopics: false,
+        name: "Fundamentals of Computer Science 1",
+        description: "Intro to CS",
+        maxCredits: 4,
+        minCredits: 4,
+        attributes: [],
+        coreqs: {},
+        prereqs: {},
+        postreqs: {},
+      },
+    ],
+    sections: {
+      "CS2500": [
+        {
+          crn: "12345",
+          name: "Fundamentals of Computer Science 1",
+          description: "Intro to CS",
+          sectionNumber: "01",
+          partOfTerm: "1",
+          seatCapacity: 100,
+          seatRemaining: 25,
+          waitlistCapacity: 10,
+          waitlistRemaining: 5,
+          classType: "Lecture",
+          honors: false,
+          campus: "BOS",
+          meetingTimes: [],
+          faculty: [],
+          xlist: [],
+          coreqs: {},
+          prereqs: {},
+        },
+      ],
+    },
+    attributes: [{ code: "NUP-WI", name: "NUpath Writing Intensive" }],
+    subjects: [{ code: "CS", description: "Computer Science" }],
+    campuses: [{ code: "BOS", description: "Boston" }],
+  };
+
+  test("valid full cache object parses successfully", () => {
+    const result = ScraperBannerCache.safeParse(validCache);
+    assert.equal(result.success, true);
+  });
+
+  test("invalid version (not 5) rejects", () => {
+    const result = ScraperBannerCache.safeParse({
+      ...validCache,
+      version: 4,
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("invalid timestamp (not ISO datetime) rejects", () => {
+    const result = ScraperBannerCache.safeParse({
+      ...validCache,
+      timestamp: "not-a-date",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects non-ISO timestamp format", () => {
+    const result = ScraperBannerCache.safeParse({
+      ...validCache,
+      timestamp: "01/15/2025 10:30:00",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields at top level (strictObject)", () => {
+    const result = ScraperBannerCache.safeParse({
+      ...validCache,
+      extra: "field",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects missing courses field", () => {
+    const { courses: _, ...incomplete } = validCache;
+    const result = ScraperBannerCache.safeParse(incomplete);
+    assert.equal(result.success, false);
+  });
+
+  test("rejects missing term field", () => {
+    const { term: _, ...incomplete } = validCache;
+    const result = ScraperBannerCache.safeParse(incomplete);
+    assert.equal(result.success, false);
+  });
+});

--- a/packages/scraper/src/schemas/scraper/static-config.test.ts
+++ b/packages/scraper/src/schemas/scraper/static-config.test.ts
@@ -1,0 +1,363 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  StaticCampus,
+  StaticCampusesConfig,
+  StaticBuilding,
+  StaticBuildingsConfig,
+  StaticSubject,
+  StaticSubjectsConfig,
+  StaticNupath,
+  StaticNupathsConfig,
+  StaticPartOfTermConfig,
+  StaticTermConfig,
+  StaticManifestConfig,
+} from "./static-config.js";
+
+describe("StaticCampus", () => {
+  test("valid campus with all fields", () => {
+    const result = StaticCampus.safeParse({
+      code: "BOS",
+      name: "Boston",
+      group: "Main",
+      aliases: ["boston"],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid campus without optional aliases", () => {
+    const result = StaticCampus.safeParse({
+      code: "BOS",
+      name: "Boston",
+      group: "Main",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing required group", () => {
+    const result = StaticCampus.safeParse({
+      code: "BOS",
+      name: "Boston",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticCampus.safeParse({
+      code: "BOS",
+      name: "Boston",
+      group: "Main",
+      extra: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticCampusesConfig", () => {
+  test("valid campuses config", () => {
+    const result = StaticCampusesConfig.safeParse({
+      campuses: [{ code: "BOS", name: "Boston", group: "Main" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid with empty campuses array", () => {
+    const result = StaticCampusesConfig.safeParse({ campuses: [] });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing campuses key", () => {
+    const result = StaticCampusesConfig.safeParse({});
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticCampusesConfig.safeParse({
+      campuses: [],
+      extra: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticBuilding", () => {
+  test("valid building with all fields", () => {
+    const result = StaticBuilding.safeParse({
+      code: "WVH",
+      name: "West Village H",
+      campus: "BOS",
+      aliases: ["west village h"],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid building without optional aliases", () => {
+    const result = StaticBuilding.safeParse({
+      code: "WVH",
+      name: "West Village H",
+      campus: "BOS",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing required campus", () => {
+    const result = StaticBuilding.safeParse({
+      code: "WVH",
+      name: "West Village H",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticBuilding.safeParse({
+      code: "WVH",
+      name: "West Village H",
+      campus: "BOS",
+      floors: 5,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticBuildingsConfig", () => {
+  test("valid buildings config", () => {
+    const result = StaticBuildingsConfig.safeParse({
+      buildings: [{ code: "WVH", name: "West Village H", campus: "BOS" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing buildings key", () => {
+    const result = StaticBuildingsConfig.safeParse({});
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticSubject", () => {
+  test("valid subject with all fields", () => {
+    const result = StaticSubject.safeParse({
+      code: "CS",
+      description: "Computer Science",
+      aliases: ["comp sci"],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid subject without optional aliases", () => {
+    const result = StaticSubject.safeParse({
+      code: "CS",
+      description: "Computer Science",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing required description", () => {
+    const result = StaticSubject.safeParse({
+      code: "CS",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticSubject.safeParse({
+      code: "CS",
+      description: "Computer Science",
+      department: "Khoury",
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticSubjectsConfig", () => {
+  test("valid subjects config", () => {
+    const result = StaticSubjectsConfig.safeParse({
+      subjects: [{ code: "CS", description: "Computer Science" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing subjects key", () => {
+    const result = StaticSubjectsConfig.safeParse({});
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticNupath", () => {
+  test("valid nupath with all fields", () => {
+    const result = StaticNupath.safeParse({
+      code: "WI",
+      short: "Writing Intensive",
+      name: "Writing Intensive NUpath",
+      aliases: ["writing"],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid nupath without optional aliases", () => {
+    const result = StaticNupath.safeParse({
+      code: "WI",
+      short: "Writing Intensive",
+      name: "Writing Intensive NUpath",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing required short", () => {
+    const result = StaticNupath.safeParse({
+      code: "WI",
+      name: "Writing Intensive NUpath",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticNupath.safeParse({
+      code: "WI",
+      short: "Writing Intensive",
+      name: "Writing Intensive NUpath",
+      credits: 4,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticNupathsConfig", () => {
+  test("valid nupaths config", () => {
+    const result = StaticNupathsConfig.safeParse({
+      nupaths: [
+        {
+          code: "WI",
+          short: "Writing Intensive",
+          name: "Writing Intensive NUpath",
+        },
+      ],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing nupaths key", () => {
+    const result = StaticNupathsConfig.safeParse({});
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticPartOfTermConfig", () => {
+  test("valid with all fields", () => {
+    const result = StaticPartOfTermConfig.safeParse({
+      code: "1",
+      name: "Full Term",
+      activeUntil: "2025-12-15",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid with only required code", () => {
+    const result = StaticPartOfTermConfig.safeParse({
+      code: "1",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing required code", () => {
+    const result = StaticPartOfTermConfig.safeParse({
+      name: "Full Term",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticPartOfTermConfig.safeParse({
+      code: "1",
+      extra: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticTermConfig", () => {
+  test("valid with all fields", () => {
+    const result = StaticTermConfig.safeParse({
+      term: 202510,
+      name: "Fall 2025",
+      activeUntil: "2025-12-15",
+      splitByPartOfTerm: true,
+      parts: [{ code: "1", name: "Full Term" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid with only required fields", () => {
+    const result = StaticTermConfig.safeParse({
+      term: 202510,
+      activeUntil: "2025-12-15",
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing required activeUntil", () => {
+    const result = StaticTermConfig.safeParse({
+      term: 202510,
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("term must be an integer", () => {
+    const result = StaticTermConfig.safeParse({
+      term: 2025.5,
+      activeUntil: "2025-12-15",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("term rejects string", () => {
+    const result = StaticTermConfig.safeParse({
+      term: "202510",
+      activeUntil: "2025-12-15",
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticTermConfig.safeParse({
+      term: 202510,
+      activeUntil: "2025-12-15",
+      extra: true,
+    });
+    assert.equal(result.success, false);
+  });
+});
+
+describe("StaticManifestConfig", () => {
+  test("valid manifest config", () => {
+    const result = StaticManifestConfig.safeParse({
+      terms: [{ term: 202510, activeUntil: "2025-12-15" }],
+    });
+    assert.equal(result.success, true);
+  });
+
+  test("valid with empty terms array", () => {
+    const result = StaticManifestConfig.safeParse({ terms: [] });
+    assert.equal(result.success, true);
+  });
+
+  test("rejects missing terms key", () => {
+    const result = StaticManifestConfig.safeParse({});
+    assert.equal(result.success, false);
+  });
+
+  test("rejects extra fields (strictObject)", () => {
+    const result = StaticManifestConfig.safeParse({
+      terms: [],
+      version: 1,
+    });
+    assert.equal(result.success, false);
+  });
+
+  test("rejects invalid term inside array", () => {
+    const result = StaticManifestConfig.safeParse({
+      terms: [{ term: "notanumber", activeUntil: "2025-12-15" }],
+    });
+    assert.equal(result.success, false);
+  });
+});

--- a/packages/scraper/src/update/notifs.test.ts
+++ b/packages/scraper/src/update/notifs.test.ts
@@ -1,0 +1,204 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { sendNotifications, type Notif, type NotificationSender } from "./notifs";
+
+function makeNotif(overrides: Partial<Notif> = {}): Notif {
+  return {
+    id: 1,
+    term: "202510",
+    sectionCrn: "12345",
+    uid: "user1",
+    method: "SMS",
+    count: 0,
+    limit: 5,
+    courseSubject: "CS",
+    courseNumber: "2500",
+    phoneNumber: "+11234567890",
+    phoneNumberVerified: true,
+    ...overrides,
+  };
+}
+
+function makeSender(): NotificationSender & { calls: Array<{ to: string; message: string }> } {
+  const calls: Array<{ to: string; message: string }> = [];
+  return {
+    calls,
+    async sendSMS(to: string, message: string) {
+      calls.push({ to, message });
+    },
+  };
+}
+
+/** Creates a chainable mock db that records calls. */
+function makeMockDb() {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+
+  function chainable(): any {
+    const chain: any = {
+      set(...args: unknown[]) {
+        calls.push({ method: "set", args });
+        return chain;
+      },
+      where(...args: unknown[]) {
+        calls.push({ method: "where", args });
+        return Promise.resolve();
+      },
+      values(...args: unknown[]) {
+        calls.push({ method: "values", args });
+        return chain;
+      },
+      catch(fn: (err: Error) => void) {
+        return Promise.resolve().catch(fn);
+      },
+    };
+    return chain;
+  }
+
+  return {
+    calls,
+    update() {
+      calls.push({ method: "update", args: [] });
+      return chainable();
+    },
+    insert() {
+      calls.push({ method: "insert", args: [] });
+      return chainable();
+    },
+  };
+}
+
+function makeLogger() {
+  const logs: Array<{ level: string; msg: string }> = [];
+  return {
+    logs,
+    info(msg: string) {
+      logs.push({ level: "info", msg });
+    },
+    warn(msg: string) {
+      logs.push({ level: "warn", msg });
+    },
+    error(msg: string) {
+      logs.push({ level: "error", msg });
+    },
+  };
+}
+
+describe("sendNotifications", () => {
+  test("sends SMS for seat notifications with correct message format", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 1);
+    assert.equal(sender.calls[0].to, "+11234567890");
+    assert.ok(sender.calls[0].message.includes("A seat opened up in CS 2500"));
+    assert.ok(sender.calls[0].message.includes("CRN: 12345"));
+    assert.ok(
+      sender.calls[0].message.includes(
+        "https://searchneu.com/catalog/202510/CS%202500",
+      ),
+    );
+  });
+
+  test("sends SMS for waitlist notifications with different message format", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([], [notif], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 1);
+    assert.ok(
+      sender.calls[0].message.includes("A waitlist seat has opened up in CS 2500"),
+    );
+  });
+
+  test("skips notifications when phoneNumber is null", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif({ phoneNumber: null });
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 0);
+  });
+
+  test("skips notifications when phoneNumberVerified is false", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif({ phoneNumberVerified: false });
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 0);
+  });
+
+  test("when count >= limit, marks tracker as deleted without sending SMS", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif({ count: 5, limit: 5 });
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.equal(sender.calls.length, 0);
+    assert.ok(db.calls.some((c) => c.method === "update"));
+  });
+
+  test("on successful SMS: logs notification and updates tracker", async () => {
+    const sender = makeSender();
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.ok(logger.logs.some((l) => l.level === "info" && l.msg.includes("+11234567890")));
+    // insert for notification log, update for message count
+    assert.ok(db.calls.some((c) => c.method === "insert"));
+    assert.ok(db.calls.some((c) => c.method === "update"));
+  });
+
+  test("on Twilio error 21610: deletes all trackers for that user", async () => {
+    const sender: NotificationSender = {
+      async sendSMS() {
+        const err = new Error("Unsubscribed") as Error & { code: number };
+        err.code = 21610;
+        throw err;
+      },
+    };
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.ok(logger.logs.some((l) => l.level === "warn" && l.msg.includes("unsubscribed")));
+    assert.ok(db.calls.some((c) => c.method === "update"));
+  });
+
+  test("on generic error: logs error message", async () => {
+    const sender: NotificationSender = {
+      async sendSMS() {
+        throw new Error("Something went wrong");
+      },
+    };
+    const db = makeMockDb();
+    const logger = makeLogger();
+    const notif = makeNotif();
+
+    await sendNotifications([notif], [], db as any, sender, logger);
+
+    assert.ok(
+      logger.logs.some(
+        (l) => l.level === "error" && l.msg.includes("+11234567890"),
+      ),
+    );
+  });
+});

--- a/packages/scraper/src/upload/main.test.ts
+++ b/packages/scraper/src/upload/main.test.ts
@@ -1,0 +1,175 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { filterScrapeByPartOfTerm } from "./main";
+
+function makeSection(overrides: Record<string, unknown> = {}) {
+  return {
+    crn: "10001",
+    name: "Test Section",
+    description: "A test section",
+    sectionNumber: "01",
+    partOfTerm: "1",
+    seatCapacity: 50,
+    seatRemaining: 10,
+    waitlistCapacity: 10,
+    waitlistRemaining: 5,
+    classType: "Lecture",
+    honors: false,
+    campus: "Boston",
+    meetingTimes: [],
+    faculty: [],
+    xlist: [],
+    coreqs: {},
+    prereqs: {},
+    ...overrides,
+  };
+}
+
+function makeScrape(
+  courses: Array<{
+    subject: string;
+    courseNumber: string;
+    name?: string;
+  }>,
+  sections: Record<string, Array<ReturnType<typeof makeSection>>>,
+) {
+  return {
+    version: 5 as const,
+    timestamp: "2025-01-01T00:00:00Z",
+    term: { code: "202510", description: "Spring 2025" },
+    courses: courses.map((c) => ({
+      subject: c.subject,
+      courseNumber: c.courseNumber,
+      specialTopics: false,
+      name: c.name ?? "Test Course",
+      description: "A test course",
+      maxCredits: 4,
+      minCredits: 4,
+      attributes: [],
+      coreqs: {},
+      prereqs: {},
+      postreqs: {},
+    })),
+    sections,
+    attributes: [],
+    subjects: [],
+    campuses: [],
+  };
+}
+
+describe("filterScrapeByPartOfTerm", () => {
+  test("filters sections by partOfTerm value", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "A" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.sections["CS2500"].length, 1);
+    assert.equal(result.sections["CS2500"][0].crn, "10001");
+  });
+
+  test("removes courses with no matching sections", () => {
+    const scrape = makeScrape(
+      [
+        { subject: "CS", courseNumber: "2500" },
+        { subject: "CS", courseNumber: "2510" },
+      ],
+      {
+        CS2500: [makeSection({ crn: "10001", partOfTerm: "A" })],
+        CS2510: [makeSection({ crn: "10002", partOfTerm: "B" })],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "A");
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.courses[0].subject, "CS");
+    assert.equal(result.courses[0].courseNumber, "2500");
+    assert.equal(result.sections["CS2510"], undefined);
+  });
+
+  test("keeps courses that have at least one matching section", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "A" }),
+          makeSection({ crn: "10003", partOfTerm: "1" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.sections["CS2500"].length, 2);
+  });
+
+  test("all sections match: returns equivalent scrape", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "1" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.courses.length, 1);
+    assert.equal(result.sections["CS2500"].length, 2);
+  });
+
+  test("no sections match: returns empty courses and sections", () => {
+    const scrape = makeScrape(
+      [{ subject: "CS", courseNumber: "2500" }],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "A" }),
+          makeSection({ crn: "10002", partOfTerm: "B" }),
+        ],
+      },
+    );
+
+    const result = filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(result.courses.length, 0);
+    assert.deepStrictEqual(result.sections, {});
+  });
+
+  test("does not mutate the original scrape object", () => {
+    const scrape = makeScrape(
+      [
+        { subject: "CS", courseNumber: "2500" },
+        { subject: "CS", courseNumber: "2510" },
+      ],
+      {
+        CS2500: [
+          makeSection({ crn: "10001", partOfTerm: "1" }),
+          makeSection({ crn: "10002", partOfTerm: "A" }),
+        ],
+        CS2510: [makeSection({ crn: "10003", partOfTerm: "A" })],
+      },
+    );
+
+    const originalCourseCount = scrape.courses.length;
+    const originalCS2500Count = scrape.sections["CS2500"].length;
+    const originalCS2510Count = scrape.sections["CS2510"].length;
+
+    filterScrapeByPartOfTerm(scrape, "1");
+
+    assert.equal(scrape.courses.length, originalCourseCount);
+    assert.equal(scrape.sections["CS2500"].length, originalCS2500Count);
+    assert.equal(scrape.sections["CS2510"].length, originalCS2510Count);
+  });
+});

--- a/packages/scraper/src/upload/main.ts
+++ b/packages/scraper/src/upload/main.ts
@@ -183,7 +183,7 @@ export async function uploadCatalogTerm(
  * Returns a filtered copy of the scrape with only sections matching the
  * given partOfTerm, and only courses that still have sections after filtering.
  */
-function filterScrapeByPartOfTerm(
+export function filterScrapeByPartOfTerm(
   scrape: z.infer<typeof ScraperBannerCache>,
   partOfTerm: string,
 ): z.infer<typeof ScraperBannerCache> {

--- a/packages/scraper/src/upload/types.test.ts
+++ b/packages/scraper/src/upload/types.test.ts
@@ -1,0 +1,36 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { chunk } from "./types";
+
+describe("chunk", () => {
+  test("empty array returns empty array", () => {
+    assert.deepStrictEqual(chunk([], 2), []);
+  });
+
+  test("array divides evenly", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3, 4], 2), [
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  test("array with remainder", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3, 4, 5], 2), [
+      [1, 2],
+      [3, 4],
+      [5],
+    ]);
+  });
+
+  test("single element array", () => {
+    assert.deepStrictEqual(chunk([42], 3), [[42]]);
+  });
+
+  test("size larger than array returns single chunk", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3], 10), [[1, 2, 3]]);
+  });
+
+  test("size of 1 returns array of single-element arrays", () => {
+    assert.deepStrictEqual(chunk([1, 2, 3], 1), [[1], [2], [3]]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 318 unit tests across 20 test files for the `@sneu/scraper` package (previously had zero tests)
- Tests cover all major modules: data transformation, HTML parsing, fetch infrastructure, schemas, scraping steps, and upload/update utilities
- Uses Node.js native test runner (`node:test`) with `nock` for HTTP mocking

### Test breakdown by commit:
| Commit | Module | Tests |
|--------|--------|-------|
| events + config + endpoints | Core utilities | 16 |
| Banner schemas | API response validation | 68 |
| marshall | `arrangeCourses`, `parseMeetingTimes` | 27 |
| reqs | `parsePrereqs`, `parseCoreqs`, `populatePostReqs` | 23 |
| scraper schemas | Cache + static config schemas | 87 |
| sections + terms + campuses | Scraping steps (direct fetch) | 11 |
| prereqs + coreqs steps | Scraping steps (FetchEngine) | 9 |
| fetch infrastructure | `$fetch` retry + `FetchEngine` class | 25 |
| upload/update utilities | `chunk`, `filterScrapeByPartOfTerm`, `sendNotifications` | 20 |
| faculty + names + descriptions | Scraping steps (FetchEngine) | 24 |

### Not tested (intentionally skipped):
- `generate/main.ts` — orchestrator requiring full pipeline mock
- `upload/steps/*.ts` — tightly coupled to drizzle DB transactions
- `update/main.ts` — coupled to both scraper and DB queries
- Trivial `z.string()` schemas (sectionCatalogDetails, sectionCoreqs, etc.)

## Test plan
- [x] All 318 tests pass with `node --test --import tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)