### PR TITLE
update generation algo to take into account coreqs

### DIFF
--- a/apps/searchneu/app/api/scheduler/saved-plans/route.ts
+++ b/apps/searchneu/app/api/scheduler/saved-plans/route.ts
@@ -67,10 +67,7 @@ export async function POST(req: NextRequest) {
         .select()
         .from(savedPlansT)
         .where(
-          and(
-            eq(savedPlansT.userId, user.id),
-            eq(savedPlansT.termId, term.id),
-          ),
+          and(eq(savedPlansT.userId, user.id), eq(savedPlansT.termId, term.id)),
         );
       planName = `Plan ${existingPlans.length + 1}`;
     }

--- a/apps/searchneu/app/api/scheduler/saved-plans/route.ts
+++ b/apps/searchneu/app/api/scheduler/saved-plans/route.ts
@@ -55,6 +55,11 @@ export async function POST(req: NextRequest) {
   }
 
   try {
+    const term = await getTerm(body.term);
+    if (!term) {
+      return Response.json({ error: "term not found" }, { status: 400 });
+    }
+
     // Auto-generate name if not provided
     let planName = body.name;
     if (!planName) {
@@ -64,15 +69,10 @@ export async function POST(req: NextRequest) {
         .where(
           and(
             eq(savedPlansT.userId, user.id),
-            eq(savedPlansT.termId, parseInt(body.term, 10)),
+            eq(savedPlansT.termId, term.id),
           ),
         );
       planName = `Plan ${existingPlans.length + 1}`;
-    }
-
-    const term = await getTerm(body.term);
-    if (!term) {
-      return Response.json({ error: "term not found" }, { status: 400 });
     }
 
     // Create the saved plan

--- a/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
+++ b/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
@@ -12,7 +12,7 @@ import { getScheduleKey } from "@/lib/scheduler/scheduleKey";
 import { SchedulerView } from "./calendar/SchedulerView";
 import { ScheduleSidebar } from "./right-sidebar/ScheduleSidebar";
 import { FilterPanel } from "./left-sidebar/FilterPanel";
-import { GroupedTerms, Campus, Nupath } from "@/lib/catalog/types";
+import { GroupedTerms, Campus, Nupath, Term } from "@/lib/catalog/types";
 import {
   PlanData,
   PlanCourse,
@@ -44,6 +44,7 @@ export function SchedulerWrapper({
   // Store the plan ID from when we save the plan initially
   const [planId, setPlanId] = useState<number | null>(null);
   const [planName, setPlanName] = useState<string>("Plan");
+  const [currentTerm, setCurrentTerm] = useState<Term>(terms.neu[0]);
   const searchParams = useSearchParams();
   const planIdFromUrl = searchParams.get("planId");
 
@@ -137,6 +138,17 @@ export function SchedulerWrapper({
         const planData = (await response.json()) as PlanData;
         setPlanId(planIdNum);
         setPlanName(planData.name);
+        
+        // Find and set the current term by termId
+        if (planData.termId) {
+          // Search through the already-loaded terms prop to find matching term
+          const foundTerm = Object.values(terms)
+            .flat() as Term[];
+          const matchingTerm = foundTerm.find((t) => t.id === planData.termId);
+          if (matchingTerm) {
+            setCurrentTerm(matchingTerm);
+          }
+        }
 
         // Extract locked courses and hidden sections from saved plan
         const lockedCourseIds: Set<number> = new Set();
@@ -623,6 +635,7 @@ export function SchedulerWrapper({
           lockedCourseIds={filters.lockedCourseIds ?? new Set()}
           onLockedCourseIdsChange={handleLockedCourseIdsChange}
           planId={planIdFromUrl ? parseInt(planIdFromUrl) : undefined}
+          currentTerm={currentTerm}
           onSchedulesGenerated={onSchedulesGenerated}
         />
       </div>

--- a/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
+++ b/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
@@ -138,12 +138,11 @@ export function SchedulerWrapper({
         const planData = (await response.json()) as PlanData;
         setPlanId(planIdNum);
         setPlanName(planData.name);
-        
+
         // Find and set the current term by termId
         if (planData.termId) {
           // Search through the already-loaded terms prop to find matching term
-          const foundTerm = Object.values(terms)
-            .flat() as Term[];
+          const foundTerm = Object.values(terms).flat() as Term[];
           const matchingTerm = foundTerm.find((t) => t.id === planData.termId);
           if (matchingTerm) {
             setCurrentTerm(matchingTerm);

--- a/apps/searchneu/components/scheduler/generator/left-sidebar/FilterPanel.tsx
+++ b/apps/searchneu/components/scheduler/generator/left-sidebar/FilterPanel.tsx
@@ -10,7 +10,7 @@ import {
 import { CoursesTab } from "./CoursesTab";
 import { FiltersTab } from "./FiltersTab";
 import AddCoursesModal from "../../shared/modal/AddCoursesModal";
-import { GroupedTerms } from "@/lib/catalog/types";
+import { GroupedTerms, Term } from "@/lib/catalog/types";
 
 interface FilterPanelProps {
   filters: ScheduleFilters;
@@ -23,6 +23,7 @@ interface FilterPanelProps {
   lockedCourseIds: Set<number>;
   onLockedCourseIdsChange: (ids: Set<number>) => void;
   planId?: number;
+  currentTerm?: Term | null;
   onSchedulesGenerated?: () => void;
 }
 
@@ -39,6 +40,7 @@ export function FilterPanel({
   lockedCourseIds,
   onLockedCourseIdsChange,
   planId,
+  currentTerm,
   onSchedulesGenerated,
 }: FilterPanelProps) {
   const { openFeedback } = useFeedback();
@@ -52,7 +54,7 @@ export function FilterPanel({
         open={isModalOpen}
         closeFn={() => setIsModalOpen(false)}
         terms={terms}
-        selectedTerm={null}
+        selectedTerm={currentTerm || null}
         planId={planId}
         callback={onSchedulesGenerated}
       />

--- a/apps/searchneu/components/scheduler/shared/modal/AddCoursesModal.tsx
+++ b/apps/searchneu/components/scheduler/shared/modal/AddCoursesModal.tsx
@@ -339,10 +339,7 @@ export default function AddCoursesModal(props: AddCoursesModalProps) {
             <Button
               className="cursor-pointer"
               disabled={
-                isGenerating ||
-                selectedCourseGroups.length +
-                  selectedCourseGroups.flatMap((g) => g.coreqs).length <
-                  numCourses
+                isGenerating || selectedCourseGroups.length < numCourses
               }
               onClick={() => {
                 const allCourseIds = selectedCourseGroups.flatMap((g) => [

--- a/apps/searchneu/lib/scheduler/coreqResolver.ts
+++ b/apps/searchneu/lib/scheduler/coreqResolver.ts
@@ -9,14 +9,18 @@ const isCondition = (item: RequisiteItem): item is Condition => {
   return "type" in item && "items" in item;
 };
 
-const isCourse = (item: RequisiteItem): item is { subject: string; courseNumber: string } => {
+const isCourse = (
+  item: RequisiteItem,
+): item is { subject: string; courseNumber: string } => {
   return "subject" in item && "courseNumber" in item;
 };
 
 /**
  * Recursively extract all course references from a Requisite tree
  */
-function extractCoursesFromRequisite(requisite: Requisite): Array<{ subject: string; courseNumber: string }> {
+function extractCoursesFromRequisite(
+  requisite: Requisite,
+): Array<{ subject: string; courseNumber: string }> {
   const courses: Array<{ subject: string; courseNumber: string }> = [];
 
   if (Object.keys(requisite).length === 0) {
@@ -34,7 +38,7 @@ function extractCoursesFromRequisite(requisite: Requisite): Array<{ subject: str
 
   // Cast to RequisiteItem since we've already checked it's not empty
   const item = requisite as RequisiteItem;
-  
+
   if (isCondition(item)) {
     walk(item);
   } else if (isCourse(item)) {
@@ -87,9 +91,7 @@ async function resolveCourseReferences(
  * Get all corequisite course IDs for a given course
  * Returns an array of coreq course IDs in the same term
  */
-export async function getCoreqCourseIds(
-  courseId: number,
-): Promise<number[]> {
+export async function getCoreqCourseIds(courseId: number): Promise<number[]> {
   const course = await db
     .select({
       coreqs: coursesT.coreqs,
@@ -113,16 +115,16 @@ export async function getCoreqCourseIds(
 /**
  * Build corequisite groups from a list of course IDs
  * Only groups together coreqs that are BOTH in the input list.
- * 
+ *
  * Constraint logic:
  * - If only 1 out of 2 coreqs is passed in → that 1 can stand alone
  * - If 2 out of 2 coreqs are passed in → both must be in the schedule
  * - If all N coreqs are passed in → all N must be in the schedule
- * 
+ *
  * @example
  * If courseIds = [101, 102, 103] where 101 has coreqs [102], 102 has coreqs [101]
  * Returns [[101, 102], [103]]
- * 
+ *
  * If courseIds = [101, 104] where 101 has coreqs [102], 102 has coreqs [101]
  * Returns [[101], [104]] (102 wasn't passed in, so 101 stands alone)
  */
@@ -135,7 +137,7 @@ export async function buildCoreqGroups(
   for (const courseId of courseIds) {
     const allCoreqs = await getCoreqCourseIds(courseId);
     // Filter to only include coreqs that are also in the input list
-    const relevantCoreqs = allCoreqs.filter(c => courseIds.includes(c));
+    const relevantCoreqs = allCoreqs.filter((c) => courseIds.includes(c));
     coreqMap.set(courseId, new Set(relevantCoreqs));
   }
 

--- a/apps/searchneu/lib/scheduler/coreqResolver.ts
+++ b/apps/searchneu/lib/scheduler/coreqResolver.ts
@@ -133,13 +133,16 @@ export async function buildCoreqGroups(
 ): Promise<number[][]> {
   const coreqMap = new Map<number, Set<number>>();
 
-  // Get all coreqs for each course, but only include those in the input list
-  for (const courseId of courseIds) {
-    const allCoreqs = await getCoreqCourseIds(courseId);
-    // Filter to only include coreqs that are also in the input list
-    const relevantCoreqs = allCoreqs.filter((c) => courseIds.includes(c));
+  // Get all coreqs for each course
+  const allCoreqsResults = await Promise.all(courseIds.map(getCoreqCourseIds));
+
+  // Filter to only include coreqs that are also in the input list
+  courseIds.forEach((courseId, idx) => {
+    const relevantCoreqs = allCoreqsResults[idx].filter((c) =>
+      courseIds.includes(c),
+    );
     coreqMap.set(courseId, new Set(relevantCoreqs));
-  }
+  });
 
   // Build groups: courses that are coreqs of each other (only considering passed-in courses)
   const visited = new Set<number>();

--- a/apps/searchneu/lib/scheduler/coreqResolver.ts
+++ b/apps/searchneu/lib/scheduler/coreqResolver.ts
@@ -1,0 +1,171 @@
+import { db, coursesT, subjectsT } from "@/lib/db";
+import { eq } from "drizzle-orm";
+import type { Requisite, RequisiteItem, Condition } from "@sneu/scraper/types";
+
+/**
+ * Type guards for Requisite items
+ */
+const isCondition = (item: RequisiteItem): item is Condition => {
+  return "type" in item && "items" in item;
+};
+
+const isCourse = (item: RequisiteItem): item is { subject: string; courseNumber: string } => {
+  return "subject" in item && "courseNumber" in item;
+};
+
+/**
+ * Recursively extract all course references from a Requisite tree
+ */
+function extractCoursesFromRequisite(requisite: Requisite): Array<{ subject: string; courseNumber: string }> {
+  const courses: Array<{ subject: string; courseNumber: string }> = [];
+
+  if (Object.keys(requisite).length === 0) {
+    return courses; // Empty requisite
+  }
+
+  const walk = (item: RequisiteItem) => {
+    if (isCondition(item)) {
+      item.items.forEach(walk);
+    } else if (isCourse(item)) {
+      courses.push({ subject: item.subject, courseNumber: item.courseNumber });
+    }
+    // Ignore Test items - they're not courses
+  };
+
+  // Cast to RequisiteItem since we've already checked it's not empty
+  const item = requisite as RequisiteItem;
+  
+  if (isCondition(item)) {
+    walk(item);
+  } else if (isCourse(item)) {
+    courses.push(item);
+  }
+
+  return courses;
+}
+
+/**
+ * Resolve course references to their IDs in the database
+ * Returns a Map of { subject + courseNumber } -> course ID
+ */
+async function resolveCourseReferences(
+  courseRefs: Array<{ subject: string; courseNumber: string }>,
+  termId: number,
+): Promise<Map<string, number>> {
+  if (courseRefs.length === 0) return new Map();
+
+  const coreqCourses = await db
+    .select({
+      id: coursesT.id,
+      subject: subjectsT.code,
+      courseNumber: coursesT.courseNumber,
+    })
+    .from(coursesT)
+    .innerJoin(subjectsT, eq(coursesT.subject, subjectsT.id))
+    .where(eq(coursesT.termId, termId));
+
+  const courseMap = new Map<string, number>();
+  for (const course of coreqCourses) {
+    const key = `${course.subject}:${course.courseNumber}`;
+    courseMap.set(key, course.id);
+  }
+
+  // Map references to IDs
+  const result = new Map<string, number>();
+  for (const ref of courseRefs) {
+    const key = `${ref.subject}:${ref.courseNumber}`;
+    const id = courseMap.get(key);
+    if (id) {
+      result.set(key, id);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get all corequisite course IDs for a given course
+ * Returns an array of coreq course IDs in the same term
+ */
+export async function getCoreqCourseIds(
+  courseId: number,
+): Promise<number[]> {
+  const course = await db
+    .select({
+      coreqs: coursesT.coreqs,
+      termId: coursesT.termId,
+    })
+    .from(coursesT)
+    .where(eq(coursesT.id, courseId))
+    .limit(1);
+
+  if (!course || course.length === 0) {
+    return [];
+  }
+
+  const { coreqs, termId } = course[0];
+  const courseRefs = extractCoursesFromRequisite(coreqs as Requisite);
+  const coreqMap = await resolveCourseReferences(courseRefs, termId);
+
+  return Array.from(coreqMap.values());
+}
+
+/**
+ * Build corequisite groups from a list of course IDs
+ * Only groups together coreqs that are BOTH in the input list.
+ * 
+ * Constraint logic:
+ * - If only 1 out of 2 coreqs is passed in → that 1 can stand alone
+ * - If 2 out of 2 coreqs are passed in → both must be in the schedule
+ * - If all N coreqs are passed in → all N must be in the schedule
+ * 
+ * @example
+ * If courseIds = [101, 102, 103] where 101 has coreqs [102], 102 has coreqs [101]
+ * Returns [[101, 102], [103]]
+ * 
+ * If courseIds = [101, 104] where 101 has coreqs [102], 102 has coreqs [101]
+ * Returns [[101], [104]] (102 wasn't passed in, so 101 stands alone)
+ */
+export async function buildCoreqGroups(
+  courseIds: number[],
+): Promise<number[][]> {
+  const coreqMap = new Map<number, Set<number>>();
+
+  // Get all coreqs for each course, but only include those in the input list
+  for (const courseId of courseIds) {
+    const allCoreqs = await getCoreqCourseIds(courseId);
+    // Filter to only include coreqs that are also in the input list
+    const relevantCoreqs = allCoreqs.filter(c => courseIds.includes(c));
+    coreqMap.set(courseId, new Set(relevantCoreqs));
+  }
+
+  // Build groups: courses that are coreqs of each other (only considering passed-in courses)
+  const visited = new Set<number>();
+  const groups: number[][] = [];
+
+  for (const courseId of courseIds) {
+    if (visited.has(courseId)) continue;
+
+    const group = [courseId];
+    visited.add(courseId);
+
+    // Find all courses in the coreq network
+    const queue = [courseId];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const coreqs = coreqMap.get(current) || new Set();
+
+      for (const coreq of coreqs) {
+        if (!visited.has(coreq)) {
+          group.push(coreq);
+          visited.add(coreq);
+          queue.push(coreq);
+        }
+      }
+    }
+
+    groups.push(group);
+  }
+
+  return groups;
+}

--- a/apps/searchneu/lib/scheduler/coreqResolver.ts
+++ b/apps/searchneu/lib/scheduler/coreqResolver.ts
@@ -1,5 +1,5 @@
 import { db, coursesT, subjectsT } from "@/lib/db";
-import { eq } from "drizzle-orm";
+import { eq, inArray, and } from "drizzle-orm";
 import type { Requisite, RequisiteItem, Condition } from "@sneu/scraper/types";
 
 /**
@@ -66,7 +66,15 @@ async function resolveCourseReferences(
     })
     .from(coursesT)
     .innerJoin(subjectsT, eq(coursesT.subject, subjectsT.id))
-    .where(eq(coursesT.termId, termId));
+    .where(
+      and(
+        eq(coursesT.termId, termId),
+        inArray(
+          coursesT.courseNumber,
+          courseRefs.map((r) => r.courseNumber),
+        ),
+      ),
+    );
 
   const courseMap = new Map<string, number>();
   for (const course of coreqCourses) {

--- a/apps/searchneu/lib/scheduler/generateSchedules.ts
+++ b/apps/searchneu/lib/scheduler/generateSchedules.ts
@@ -232,8 +232,14 @@ const addOptionalCourseGroups = (
 
   // Get optional group indices in order
   const optionalGroupIndices = Array.from(
-    new Set(Array.from(optionalGroupsByCourse.keys()).map(cid => groupIndexByCourseId.get(cid)))
-  ).filter((id): id is number => id !== undefined).sort((a, b) => a - b);
+    new Set(
+      Array.from(optionalGroupsByCourse.keys()).map((cid) =>
+        groupIndexByCourseId.get(cid),
+      ),
+    ),
+  )
+    .filter((id): id is number => id !== undefined)
+    .sort((a, b) => a - b);
 
   // Helper to count how many groups are in a schedule
   const countGroupsInSchedule = (schedule: SectionWithCourse[]): number => {
@@ -286,12 +292,14 @@ const addOptionalCourseGroups = (
 
     // Choice B: Try adding all sections of all courses in this group (must all fit together)
     const groupSectionsBysCourse = coursesInGroup.map(
-      courseId => optionalGroupsByCourse.get(courseId) || []
+      (courseId) => optionalGroupsByCourse.get(courseId) || [],
     );
 
     // Generate combinations for this group
-    const groupCombinations = generateCombinationsOptimized(groupSectionsBysCourse);
-    
+    const groupCombinations = generateCombinationsOptimized(
+      groupSectionsBysCourse,
+    );
+
     for (const groupCombination of groupCombinations) {
       let hasConflict = false;
 
@@ -324,7 +332,7 @@ const addOptionalCourseGroups = (
 
 /**
  * Main schedule generator.
- * 
+ *
  * - Corequisite courses are automatically grouped together
  * - If one course in a group is selected, all must be selected
  * - Each group counts as 1 towards numCourses
@@ -359,11 +367,13 @@ export const generateSchedules = async (
   // For locked courses: they must all be present, so organize by group
   const lockedGroupsToUse: SectionWithCourse[][] = [];
   for (const group of coreqGroups) {
-    const lockedCoursesInGroup = group.filter(cid => lockedGroupsByCourse.has(cid));
+    const lockedCoursesInGroup = group.filter((cid) =>
+      lockedGroupsByCourse.has(cid),
+    );
     if (lockedCoursesInGroup.length > 0) {
       // All locked courses in this group must be satisfied
       lockedGroupsToUse.push(
-        ...lockedCoursesInGroup.map(cid => lockedGroupsByCourse.get(cid)!)
+        ...lockedCoursesInGroup.map((cid) => lockedGroupsByCourse.get(cid)!),
       );
     }
   }
@@ -372,7 +382,12 @@ export const generateSchedules = async (
 
   // Edge case: No locked courses
   if (lockedCourseIds.length === 0 && optionalCourseIds.length > 0) {
-    return addOptionalCourseGroups([], optionalGroupsByCourse, coreqGroups, numCourses);
+    return addOptionalCourseGroups(
+      [],
+      optionalGroupsByCourse,
+      coreqGroups,
+      numCourses,
+    );
   }
 
   // If no optional courses, filter by group count
@@ -383,12 +398,12 @@ export const generateSchedules = async (
     // Count groups in each schedule
     return validLockedSchedules.filter((schedule) => {
       const groupCount = new Set(
-        schedule.map(s => {
+        schedule.map((s) => {
           for (const group of coreqGroups) {
             if (group.includes(s.courseId)) return coreqGroups.indexOf(group);
           }
           return -1;
-        })
+        }),
       ).size;
       return groupCount === numCourses;
     });
@@ -398,12 +413,12 @@ export const generateSchedules = async (
   for (const lockedSchedule of validLockedSchedules) {
     // Count locked groups
     const lockedGroupCount = new Set(
-      lockedSchedule.map(s => {
+      lockedSchedule.map((s) => {
         for (const group of coreqGroups) {
           if (group.includes(s.courseId)) return coreqGroups.indexOf(group);
         }
         return -1;
-      })
+      }),
     ).size;
 
     // If already too many groups, skip

--- a/apps/searchneu/lib/scheduler/generateSchedules.ts
+++ b/apps/searchneu/lib/scheduler/generateSchedules.ts
@@ -11,6 +11,7 @@ import {
 import { eq, sql } from "drizzle-orm";
 import { SectionWithCourse } from "./filters";
 import { meetingTimesToBinaryMask, masksConflict } from "./binaryMeetingTime";
+import { buildCoreqGroups } from "./coreqResolver";
 
 export const getSectionsAndMeetingTimes = (courseId: number) => {
   // This code is from the catalog page, ideally we want to abstract this in the future
@@ -209,72 +210,109 @@ const generateCombinationsOptimized = (
 };
 
 /**
- * Helper function to try adding optional courses to a base schedule.
+ * Helper function to try adding optional course groups to a base schedule.
+ * Each group is treated as a single unit - either all courses in the group are added, or none.
  */
-const addOptionalCourses = (
+const addOptionalCourseGroups = (
   baseSchedule: SectionWithCourse[],
-  optionalSectionsByCourse: SectionWithCourse[][],
+  optionalGroupsByCourse: Map<number, SectionWithCourse[]>,
+  coreqGroups: number[][],
   numCourses?: number,
 ): SectionWithCourse[][] => {
   const results: SectionWithCourse[][] = [];
   const baseMasks = baseSchedule.map(meetingTimesToBinaryMask);
 
+  // Map courseIds to which group index they belong to
+  const groupIndexByCourseId = new Map<number, number>();
+  for (let i = 0; i < coreqGroups.length; i++) {
+    for (const courseId of coreqGroups[i]) {
+      groupIndexByCourseId.set(courseId, i);
+    }
+  }
+
+  // Get optional group indices in order
+  const optionalGroupIndices = Array.from(
+    new Set(Array.from(optionalGroupsByCourse.keys()).map(cid => groupIndexByCourseId.get(cid)))
+  ).filter((id): id is number => id !== undefined).sort((a, b) => a - b);
+
+  // Helper to count how many groups are in a schedule
+  const countGroupsInSchedule = (schedule: SectionWithCourse[]): number => {
+    const groupsPresent = new Set<number>();
+    for (const section of schedule) {
+      const groupIdx = groupIndexByCourseId.get(section.courseId);
+      if (groupIdx !== undefined && optionalGroupIndices.includes(groupIdx)) {
+        groupsPresent.add(groupIdx);
+      }
+    }
+    return groupsPresent.size;
+  };
+
   const generateOptionalCombinations = (
     currentSchedule: SectionWithCourse[],
     currentMasks: bigint[],
-    courseIndex: number,
+    groupIndex: number,
   ) => {
-    // Condition: If we hit the end of the available courses
-    if (courseIndex === optionalSectionsByCourse.length) {
-      // If numCourses is defined, only push if length matches exactly
-      // Otherwise, push everything
-      if (numCourses === undefined || currentSchedule.length === numCourses) {
+    // Condition: If we hit the end of the available groups
+    if (groupIndex === optionalGroupIndices.length) {
+      const groupCount = countGroupsInSchedule(currentSchedule);
+      if (numCourses === undefined || groupCount === numCourses) {
         results.push([...currentSchedule]);
       }
       return;
     }
 
-    // Optimization: If it's impossible to reach numCourses even if we took
-    // every remaining course, stop this branch
+    // Optimization: If it's impossible to reach numCourses even if we took every remaining group
     if (numCourses !== undefined) {
-      const remainingSlots = optionalSectionsByCourse.length - courseIndex;
-      if (currentSchedule.length + remainingSlots < numCourses) return;
+      const groupCount = countGroupsInSchedule(currentSchedule);
+      const remainingGroups = optionalGroupIndices.length - groupIndex;
+      if (groupCount + remainingGroups < numCourses) return;
 
-      // Optimization: If we already have enough courses, don't try to add more
-      // Just jump to the end of the recursion to validate the current length
-      if (currentSchedule.length === numCourses) {
+      // Optimization: If we already have enough groups, jump to validation
+      if (groupCount === numCourses) {
         generateOptionalCombinations(
           currentSchedule,
           currentMasks,
-          optionalSectionsByCourse.length,
+          optionalGroupIndices.length,
         );
         return;
       }
     }
 
-    // Choice A: Try not adding this optional course
-    generateOptionalCombinations(
-      currentSchedule,
-      currentMasks,
-      courseIndex + 1,
+    const currentGroupIdx = optionalGroupIndices[groupIndex];
+    const coursesInGroup = coreqGroups[currentGroupIdx];
+
+    // Choice A: Try not adding this optional group
+    generateOptionalCombinations(currentSchedule, currentMasks, groupIndex + 1);
+
+    // Choice B: Try adding all sections of all courses in this group (must all fit together)
+    const groupSectionsBysCourse = coursesInGroup.map(
+      courseId => optionalGroupsByCourse.get(courseId) || []
     );
 
-    // Choice B: Try adding each section of this optional course
-    for (const section of optionalSectionsByCourse[courseIndex]) {
-      const sectionMask = meetingTimesToBinaryMask(section);
+    // Generate combinations for this group
+    const groupCombinations = generateCombinationsOptimized(groupSectionsBysCourse);
+    
+    for (const groupCombination of groupCombinations) {
       let hasConflict = false;
-      for (const mask of currentMasks) {
-        if (masksConflict(mask, sectionMask)) {
-          hasConflict = true;
-          break;
+
+      // Check if any section in the group conflicts with current schedule
+      for (const section of groupCombination) {
+        const sectionMask = meetingTimesToBinaryMask(section);
+        for (const mask of currentMasks) {
+          if (masksConflict(mask, sectionMask)) {
+            hasConflict = true;
+            break;
+          }
         }
+        if (hasConflict) break;
       }
 
       if (!hasConflict) {
+        const newMasks = groupCombination.map(meetingTimesToBinaryMask);
         generateOptionalCombinations(
-          [...currentSchedule, section],
-          [...currentMasks, sectionMask],
-          courseIndex + 1,
+          [...currentSchedule, ...groupCombination],
+          [...currentMasks, ...newMasks],
+          groupIndex + 1,
         );
       }
     }
@@ -284,48 +322,98 @@ const addOptionalCourses = (
   return results;
 };
 
-// the main generate schedule function
-// takes a list of locked course IDs and optional course IDs
-// returns a list of valid schedules (each schedule is a list of sections)
+/**
+ * Main schedule generator.
+ * 
+ * - Corequisite courses are automatically grouped together
+ * - If one course in a group is selected, all must be selected
+ * - Each group counts as 1 towards numCourses
+ * - Locked courses must all be present; optional courses can be any subset
+ */
 export const generateSchedules = async (
   lockedCourseIds: number[],
   optionalCourseIds: number[],
   numCourses?: number,
 ): Promise<SectionWithCourse[][]> => {
-  const lockedSectionsByCourse = await Promise.all(
-    lockedCourseIds.map(getSectionsAndMeetingTimes),
-  );
-  const optionalSectionsByCourse = await Promise.all(
-    optionalCourseIds.map(getSectionsAndMeetingTimes),
-  );
-  optionalSectionsByCourse.sort((a, b) => a.length - b.length);
+  // Build coreq groups from all courses
+  const allCourseIds = [...lockedCourseIds, ...optionalCourseIds];
+  const coreqGroups = await buildCoreqGroups(allCourseIds);
 
-  const validLockedSchedules = generateCombinationsOptimized(
-    lockedSectionsByCourse,
-  );
+  // Fetch sections for all courses
+  const [lockedSectionsByCourse, optionalSectionsByCourse] = await Promise.all([
+    Promise.all(lockedCourseIds.map(getSectionsAndMeetingTimes)),
+    Promise.all(optionalCourseIds.map(getSectionsAndMeetingTimes)),
+  ]);
+
+  // Create Maps for easier lookup by courseId
+  const lockedGroupsByCourse = new Map<number, SectionWithCourse[]>();
+  lockedCourseIds.forEach((courseId, idx) => {
+    lockedGroupsByCourse.set(courseId, lockedSectionsByCourse[idx]);
+  });
+
+  const optionalGroupsByCourse = new Map<number, SectionWithCourse[]>();
+  optionalCourseIds.forEach((courseId, idx) => {
+    optionalGroupsByCourse.set(courseId, optionalSectionsByCourse[idx]);
+  });
+
+  // For locked courses: they must all be present, so organize by group
+  const lockedGroupsToUse: SectionWithCourse[][] = [];
+  for (const group of coreqGroups) {
+    const lockedCoursesInGroup = group.filter(cid => lockedGroupsByCourse.has(cid));
+    if (lockedCoursesInGroup.length > 0) {
+      // All locked courses in this group must be satisfied
+      lockedGroupsToUse.push(
+        ...lockedCoursesInGroup.map(cid => lockedGroupsByCourse.get(cid)!)
+      );
+    }
+  }
+
+  const validLockedSchedules = generateCombinationsOptimized(lockedGroupsToUse);
 
   // Edge case: No locked courses
   if (lockedCourseIds.length === 0 && optionalCourseIds.length > 0) {
-    return addOptionalCourses([], optionalSectionsByCourse, numCourses);
+    return addOptionalCourseGroups([], optionalGroupsByCourse, coreqGroups, numCourses);
   }
 
-  // If no optional courses, filter the locked schedules by the required count
+  // If no optional courses, filter by group count
   if (optionalCourseIds.length === 0) {
-    return numCourses !== undefined
-      ? validLockedSchedules.filter((s) => s.length === numCourses)
-      : validLockedSchedules;
+    if (numCourses === undefined) {
+      return validLockedSchedules;
+    }
+    // Count groups in each schedule
+    return validLockedSchedules.filter((schedule) => {
+      const groupCount = new Set(
+        schedule.map(s => {
+          for (const group of coreqGroups) {
+            if (group.includes(s.courseId)) return coreqGroups.indexOf(group);
+          }
+          return -1;
+        })
+      ).size;
+      return groupCount === numCourses;
+    });
   }
 
   const allSchedules: SectionWithCourse[][] = [];
   for (const lockedSchedule of validLockedSchedules) {
-    // If a locked schedule is already too big, it can't be valid
-    if (numCourses !== undefined && lockedSchedule.length > numCourses)
-      continue;
+    // Count locked groups
+    const lockedGroupCount = new Set(
+      lockedSchedule.map(s => {
+        for (const group of coreqGroups) {
+          if (group.includes(s.courseId)) return coreqGroups.indexOf(group);
+        }
+        return -1;
+      })
+    ).size;
 
-    const schedulesWithOptional = addOptionalCourses(
+    // If already too many groups, skip
+    if (numCourses !== undefined && lockedGroupCount > numCourses) continue;
+
+    const schedulesWithOptional = addOptionalCourseGroups(
       lockedSchedule,
-      optionalSectionsByCourse,
-      numCourses, // Pass target down
+      optionalGroupsByCourse,
+      coreqGroups,
+      numCourses ? numCourses - lockedGroupCount : undefined,
     );
     allSchedules.push(...schedulesWithOptional);
   }

--- a/apps/searchneu/lib/scheduler/types.ts
+++ b/apps/searchneu/lib/scheduler/types.ts
@@ -14,7 +14,9 @@ export interface PlanSection {
 }
 
 export interface PlanData {
+  id: number;
   name: string;
+  termId: number;
   startTime?: number;
   endTime?: number;
   freeDays?: string[];


### PR DESCRIPTION
# Pull Request

- Updated schedule generation to make sure returned schedules contain all passed in coreqs
- Updated add course modal to count coreqs together as 1 course instead of however distinct courses they are
- Updated add course modal to use the same term as the saved plan rather than just defaulting to the most recent term
- Fix auto plan naming to be an incrementing integer

Closes https://sandboxneu.slack.com/archives/C0993L6GW10/p1774828388053049

## Type of Change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a PCP (ie changes in deps, database, infrastructure, or package exports)

## Testing

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- https://searchneu-git-fix-scheduler-coreqs-sandboxneu.vercel.app/scheduler

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] I have run a build for the entire monorepo
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All commits are atomic and my branch is cleaned (no WIP commits)
