### PR TITLE
UI updates

### DIFF
--- a/apps/searchneu/components/ClientLayout.tsx
+++ b/apps/searchneu/components/ClientLayout.tsx
@@ -2,6 +2,7 @@
 
 import { Toaster } from "sonner";
 import FeedbackModal from "@/components/feedback/FeedbackModal";
+import { FeedbackProvider } from "@/components/feedback/FeedbackContext";
 
 export function ClientLayout({ children }: { children: React.ReactNode }) {
   // useEffect(() => {
@@ -20,20 +21,22 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
   // }, []);
 
   return (
-    <div>
-      <main className="min-h-[100dvh] w-screen grow">{children}</main>
-      <FeedbackModal />
-      <Toaster
-        toastOptions={{
-          classNames: {
-            toast:
-              "!border-l-8 !border-l-[#F15B50] !text-[13px] !w-[322px] !h-[64px]",
-            cancelButton: "!bg-white !p-0",
-            icon: "!w-[35.77px] !h-[32.95px]",
-            description: "!text-[11px] !-mt-1",
-          },
-        }}
-      />
-    </div>
+    <FeedbackProvider>
+      <div>
+        <main className="min-h-[100dvh] w-screen grow">{children}</main>
+        <FeedbackModal />
+        <Toaster
+          toastOptions={{
+            classNames: {
+              toast:
+                "!border-l-8 !border-l-[#F15B50] !text-[13px] !w-[322px] !h-[64px]",
+              cancelButton: "!bg-white !p-0",
+              icon: "!w-[35.77px] !h-[32.95px]",
+              description: "!text-[11px] !-mt-1",
+            },
+          }}
+        />
+      </div>
+    </FeedbackProvider>
   );
 }

--- a/apps/searchneu/components/feedback/FeedbackContext.tsx
+++ b/apps/searchneu/components/feedback/FeedbackContext.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback } from "react";
+
+interface FeedbackContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openFeedback: () => void;
+}
+
+const FeedbackContext = createContext<FeedbackContextValue | null>(null);
+
+export function FeedbackProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const openFeedback = useCallback(() => setOpen(true), []);
+
+  return (
+    <FeedbackContext.Provider value={{ open, setOpen, openFeedback }}>
+      {children}
+    </FeedbackContext.Provider>
+  );
+}
+
+export function useFeedback() {
+  const context = useContext(FeedbackContext);
+  if (!context) {
+    throw new Error("useFeedback must be used within a FeedbackProvider");
+  }
+  return context;
+}

--- a/apps/searchneu/components/feedback/FeedbackModal.tsx
+++ b/apps/searchneu/components/feedback/FeedbackModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import FeedbackForm from "./FeedbackForm";
 import {
   Dialog,
@@ -5,10 +7,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "../ui/dialog";
+import { useFeedback } from "./FeedbackContext";
 
 export default function FeedbackModal() {
+  const { open, setOpen } = useFeedback();
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <button className="bg-r4 fixed right-0 bottom-56 z-10 flex origin-bottom-right rotate-[-90deg] flex-col rounded-t-sm px-4 py-1 text-xs text-white uppercase">
           Feedback

--- a/apps/searchneu/components/scheduler/dashboard/PlanCard/FilterTags.tsx
+++ b/apps/searchneu/components/scheduler/dashboard/PlanCard/FilterTags.tsx
@@ -58,7 +58,7 @@ export function FilterTags({ plan, campuses, nupaths }: FilterTagsProps) {
   filterTags.push(
     <div
       key="location"
-      className="bg-neu2 text-neu8 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium"
+      className="border-neu3 text-neu8 inline-flex items-center gap-1.5 rounded-full border bg-white px-3 py-1 text-xs font-medium"
     >
       <MapPin className="h-3 w-3" />
       {`${campusName}${remote}`}
@@ -78,7 +78,7 @@ export function FilterTags({ plan, campuses, nupaths }: FilterTagsProps) {
       filterTags.push(
         <div
           key="time"
-          className="bg-neu2 text-neu8 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium"
+          className="border-neu3 text-neu8 inline-flex items-center gap-1.5 rounded-full border bg-white px-3 py-1 text-xs font-medium"
         >
           <Clock className="h-3 w-3" />
           {timeParts.join(", ")}
@@ -93,7 +93,7 @@ export function FilterTags({ plan, campuses, nupaths }: FilterTagsProps) {
     filterTags.push(
       <div
         key="free-days"
-        className="bg-neu2 text-neu8 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium"
+        className="border-neu3 text-neu8 inline-flex items-center gap-1.5 rounded-full border bg-white px-3 py-1 text-xs font-medium"
       >
         {freeDaysText}
       </div>,
@@ -109,7 +109,7 @@ export function FilterTags({ plan, campuses, nupaths }: FilterTagsProps) {
       filterTags.push(
         <div
           key="nupaths"
-          className="bg-neu2 text-neu8 gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium"
+          className="border-neu3 text-neu8 gap-1.5 rounded-full border bg-white px-3 py-1 text-xs font-medium"
         >
           <span className="text-neu7 mb-3 text-xs font-bold">NU Paths </span>{" "}
           {nupathDisplays.join(", ")}

--- a/apps/searchneu/components/scheduler/dashboard/PlanCard/PlanCard.tsx
+++ b/apps/searchneu/components/scheduler/dashboard/PlanCard/PlanCard.tsx
@@ -62,14 +62,14 @@ export function PlanCard({ plan, onDelete, campuses, nupaths }: PlanCardProps) {
         <div className="flex items-center gap-3">
           <button
             onClick={handleEdit}
-            className="border-neu3 text-neu8 hover:bg-neu1 hover:text-neu9 flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            className="border-neu3 bg-neu25 text-neu8 hover:bg-neu3 hover:text-neu9 flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Pencil className="h-4 w-4" />
             Edit Plan
           </button>
           <button
             onClick={handleDelete}
-            className="border-neu3 text-neu8 hover:border-red hover:bg-red/5 hover:text-red flex items-center rounded-full border px-3 py-1.5 transition-colors"
+            className="border-neu3 bg-neu25 text-neu8 hover:bg-red/5 hover:text-red flex cursor-pointer items-center rounded-full border px-3 py-1.5 transition-colors"
           >
             <Trash2 className="h-4 w-4" />
           </button>
@@ -101,11 +101,11 @@ export function PlanCard({ plan, onDelete, campuses, nupaths }: PlanCardProps) {
               return (
                 <div
                   key={course.courseId}
-                  className="text-neu8 border-neu3 relative flex items-center gap-2 overflow-hidden rounded-lg border bg-white px-3 py-2.5 text-sm shadow-sm"
+                  className="text-neu8 relative flex items-center gap-2 overflow-hidden rounded-lg bg-[#F8F9F9] px-3 py-2.5 text-sm"
                 >
                   {/* Thin vertical color bar on left border */}
                   <div
-                    className="absolute top-0 left-0 h-full w-1"
+                    className="absolute top-0 left-0 h-full w-2"
                     style={{ backgroundColor: color.accent }}
                   />
                   <span className="text-base font-bold">
@@ -174,7 +174,8 @@ export function PlanCard({ plan, onDelete, campuses, nupaths }: PlanCardProps) {
               return (
                 <div
                   key={schedule.id}
-                  className="border-neu3 relative flex min-w-50 shrink-0 flex-col rounded-lg border bg-white p-3 shadow-sm"
+                  onClick={handleEdit}
+                  className="border-neu3 relative flex min-w-50 shrink-0 cursor-pointer flex-col rounded-xl border bg-[#F8F9F9] p-3 transition-colors hover:bg-[#F0F1F1]"
                 >
                   {/* Mini Calendar */}
                   <div className="mb-2">
@@ -202,13 +203,12 @@ export function PlanCard({ plan, onDelete, campuses, nupaths }: PlanCardProps) {
                       return (
                         <span
                           key={courseKey}
-                          className="bg-neu1 text-neu8 flex items-center overflow-hidden rounded px-1.5 py-0.5 text-xs font-medium"
+                          className="text-neu8 flex items-center overflow-hidden rounded border px-1.5 py-0.5 text-xs font-medium"
+                          style={{
+                            borderColor: color.accent,
+                            backgroundColor: color.fill,
+                          }}
                         >
-                          {/* Thin vertical color bar */}
-                          <div
-                            className="mr-1 h-full w-0.5 shrink-0"
-                            style={{ backgroundColor: color.accent }}
-                          />
                           {courseKey.replace(" ", "")}
                         </span>
                       );

--- a/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
+++ b/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
@@ -648,7 +648,7 @@ export function SchedulerWrapper({
           allSchedules={schedules}
           filteredSchedules={filteredSchedules}
           favoritedKeys={favoritedSchedules}
-          selectedScheduleKey={selectedScheduleKey}
+          selectedScheduleKey={currentScheduleKey}
           colorMap={colorMap}
           onSelectSchedule={setSelectedScheduleKey}
           onToggleFavorite={handleToggleFavorite}

--- a/apps/searchneu/components/scheduler/generator/calendar/CalendarView.tsx
+++ b/apps/searchneu/components/scheduler/generator/calendar/CalendarView.tsx
@@ -29,6 +29,7 @@ export function CalendarView({ schedule, colorMap }: CalendarViewProps) {
   const [popupState, setPopupState] = useState<{
     section: SectionWithCourse;
     rect: DOMRect;
+    openedAt: number;
   } | null>(null);
 
   const scheduledCourses = schedule.filter(
@@ -75,7 +76,7 @@ export function CalendarView({ schedule, colorMap }: CalendarViewProps) {
       {/* Calendar Grid */}
       <div className="relative">
         <div
-          className="grid grid-cols-[65px_repeat(7,1fr)] pt-3"
+          className="grid grid-cols-[65px_repeat(7,1fr)] pt-3 pr-2"
           style={{ height: `${minCalendarHeight + 12}px` }}
         >
           {/* Time Column */}
@@ -147,6 +148,7 @@ export function CalendarView({ schedule, colorMap }: CalendarViewProps) {
                           setPopupState({
                             section,
                             rect: e.currentTarget.getBoundingClientRect(),
+                            openedAt: Date.now(),
                           });
                         }}
                       >
@@ -204,6 +206,7 @@ export function CalendarView({ schedule, colorMap }: CalendarViewProps) {
       </div>
       {popupState && (
         <CourseInfoPopup
+          key={popupState.openedAt}
           section={popupState.section}
           color={getSectionColor(popupState.section, colorMap)}
           anchorRect={popupState.rect}

--- a/apps/searchneu/components/scheduler/generator/calendar/CourseInfoPopup/CourseInfoPopup.tsx
+++ b/apps/searchneu/components/scheduler/generator/calendar/CourseInfoPopup/CourseInfoPopup.tsx
@@ -14,6 +14,7 @@ interface CourseInfoPopupProps {
   color: CourseColor | undefined;
   anchorRect: DOMRect;
   onClose: () => void;
+  positionBelow?: boolean;
 }
 
 const DAY_ABBREVS = ["S", "M", "T", "W", "R", "F", "S"];
@@ -25,14 +26,23 @@ export function CourseInfoPopup({
   color,
   anchorRect,
   onClose,
+  positionBelow = false,
 }: CourseInfoPopupProps) {
   const popupNodeRef = useRef<HTMLDivElement | null>(null);
+  const closeTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [isClosing, setIsClosing] = useState(false);
 
   const handleClose = useCallback(() => {
     setIsClosing(true);
-    setTimeout(() => onClose(), ANIM_DURATION);
+    closeTimerRef.current = setTimeout(() => onClose(), ANIM_DURATION);
   }, [onClose]);
+
+  // Cancel pending close timeout on unmount so it doesn't clear a new popup
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
 
   // Ref callback: position the popup once it mounts, using its measured height
   const popupRef = useCallback(
@@ -42,23 +52,36 @@ export function CourseInfoPopup({
 
       const popupRect = node.getBoundingClientRect();
 
-      let left = anchorRect.right + 8;
-      if (left + POPUP_WIDTH > window.innerWidth - 16) {
-        left = anchorRect.left - POPUP_WIDTH - 8;
+      let left: number;
+      let top: number;
+
+      if (positionBelow) {
+        left = anchorRect.left;
+        top = anchorRect.bottom + 8;
+        if (left + POPUP_WIDTH > window.innerWidth - 16) {
+          left = window.innerWidth - POPUP_WIDTH - 16;
+        }
+        if (top + popupRect.height > window.innerHeight - 16) {
+          top = anchorRect.top - popupRect.height - 8;
+        }
+      } else {
+        left = anchorRect.right + 8;
+        if (left + POPUP_WIDTH > window.innerWidth - 16) {
+          left = anchorRect.left - POPUP_WIDTH - 8;
+        }
+        top = anchorRect.top;
+        if (top + popupRect.height > window.innerHeight - 16) {
+          top = window.innerHeight - popupRect.height - 16;
+        }
       }
       if (left < 8) left = 8;
-
-      let top = anchorRect.top;
-      if (top + popupRect.height > window.innerHeight - 16) {
-        top = window.innerHeight - popupRect.height - 16;
-      }
       if (top < 8) top = 8;
 
       node.style.left = `${left}px`;
       node.style.top = `${top}px`;
       node.style.visibility = "visible";
     },
-    [anchorRect],
+    [anchorRect, positionBelow],
   );
 
   // Close on click outside or Escape

--- a/apps/searchneu/components/scheduler/generator/calendar/SchedulerView.tsx
+++ b/apps/searchneu/components/scheduler/generator/calendar/SchedulerView.tsx
@@ -65,6 +65,7 @@ export function SchedulerView({
   const [asyncPopupState, setAsyncPopupState] = useState<{
     section: SectionWithCourse;
     rect: DOMRect;
+    openedAt: number;
   } | null>(null);
 
   const hasSchedules = schedules.length > 0 && currentSchedule;
@@ -133,6 +134,7 @@ export function SchedulerView({
                         setAsyncPopupState({
                           section,
                           rect: e.currentTarget.getBoundingClientRect(),
+                          openedAt: Date.now(),
                         });
                       }}
                     >
@@ -172,10 +174,12 @@ export function SchedulerView({
       )}
       {asyncPopupState && (
         <CourseInfoPopup
+          key={asyncPopupState.openedAt}
           section={asyncPopupState.section}
           color={getSectionColor(asyncPopupState.section, colorMap)}
           anchorRect={asyncPopupState.rect}
           onClose={() => setAsyncPopupState(null)}
+          positionBelow
         />
       )}
     </div>

--- a/apps/searchneu/components/scheduler/generator/left-sidebar/FilterMultiSelect.tsx
+++ b/apps/searchneu/components/scheduler/generator/left-sidebar/FilterMultiSelect.tsx
@@ -76,7 +76,7 @@ export function FilterMultiSelect({
               onClick={clearAll}
               className="cursor-pointer text-xs text-[#2180E8] hover:text-[#2180E8]/80"
             >
-              Clear all
+              Clear
             </button>
           )}
 

--- a/apps/searchneu/components/scheduler/generator/left-sidebar/FilterPanel.tsx
+++ b/apps/searchneu/components/scheduler/generator/left-sidebar/FilterPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil } from "lucide-react";
+import { ArrowUpRight, Pencil } from "lucide-react";
+import { useFeedback } from "@/components/feedback/FeedbackContext";
 import {
   type ScheduleFilters,
   type SectionWithCourse,
@@ -40,6 +41,7 @@ export function FilterPanel({
   planId,
   onSchedulesGenerated,
 }: FilterPanelProps) {
+  const { openFeedback } = useFeedback();
   const [activeTab, setActiveTab] = useState<Tab>("courses");
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -108,6 +110,21 @@ export function FilterPanel({
             Edit Courses
           </span>
         </button>
+      )}
+
+      {/* Suggest a new filter - filters tab only */}
+      {activeTab === "filters" && (
+        <p className="shrink-0 text-[10px]">
+          <span className="text-neu5">Did we miss something?</span>{" "}
+          <button
+            type="button"
+            onClick={() => openFeedback()}
+            className="text-neu7 cursor-pointer font-bold hover:underline"
+          >
+            Suggest a new filter
+            <ArrowUpRight className="mb-0.5 inline h-3 w-3" />
+          </button>
+        </p>
       )}
     </div>
   );

--- a/apps/searchneu/components/scheduler/generator/left-sidebar/FiltersTab.tsx
+++ b/apps/searchneu/components/scheduler/generator/left-sidebar/FiltersTab.tsx
@@ -138,7 +138,7 @@ export function FiltersTab({
               }}
               className="cursor-pointer text-xs text-[#2180E8] hover:text-[#2180E8]/80"
             >
-              Clear all
+              Clear
             </button>
           )}
         </div>
@@ -215,7 +215,7 @@ export function FiltersTab({
               onClick={() => updateFilter("specificDaysFree", undefined)}
               className="cursor-pointer text-xs text-[#2180E8] hover:text-[#2180E8]/80"
             >
-              Clear all
+              Clear
             </button>
           )}
         </div>

--- a/apps/searchneu/components/scheduler/generator/right-sidebar/ScheduleSidebar.tsx
+++ b/apps/searchneu/components/scheduler/generator/right-sidebar/ScheduleSidebar.tsx
@@ -69,7 +69,7 @@ export function ScheduleSidebar({
     },
     {
       key: "filters",
-      label: "FILTERS",
+      label: "FILTERED",
       count: filteredSchedules.length,
     },
     {

--- a/apps/searchneu/components/scheduler/shared/MiniCalendar.tsx
+++ b/apps/searchneu/components/scheduler/shared/MiniCalendar.tsx
@@ -156,7 +156,7 @@ export const MiniCalendar = memo(function MiniCalendar({
 
       {/* Footer with plan label and star */}
       <div className="mt-1.5 flex items-center justify-between">
-        <span className="text-neu7 text-xs font-semibold">
+        <span className="text-neu7 text-[14px] font-semibold">
           Schedule {scheduleIndex + 1}
         </span>
         <button
@@ -167,8 +167,8 @@ export const MiniCalendar = memo(function MiniCalendar({
           className="cursor-pointer p-0.5"
         >
           <svg
-            width="12"
-            height="12"
+            width="18"
+            height="18"
             viewBox="0 0 24 24"
             fill={isFavorited ? "#E63946" : "none"}
             stroke={isFavorited ? "#E63946" : "#858585"}

--- a/apps/searchneu/components/scheduler/shared/modal/AddCoursesModal.tsx
+++ b/apps/searchneu/components/scheduler/shared/modal/AddCoursesModal.tsx
@@ -47,7 +47,7 @@ interface AddCoursesModalProps {
 export default function AddCoursesModal(props: AddCoursesModalProps) {
   const router = useRouter();
 
-  const [numCourses, setNumCourses] = useState<number>(1);
+  const [numCourses, setNumCourses] = useState<number>(4);
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCourseGroups, setSelectedCourseGroups] = useState<
     SelectedCourseGroupData[]


### PR DESCRIPTION
                                                                                              
  Scheduler Generator (right sidebar)                                                           
  - Fixed selected schedule not highlighting in the right sidebar when navigating to/generating
  a schedule                                                                                    
  - Renamed "FILTERS" tab to "FILTERED"                                                      
  - Made schedule name text 14px and favorite star 18x18px                                      
                                                                                                
  Scheduler Generator (left sidebar)                                                            
  - Changed "Clear all" to "Clear" on Time, Free Days, and NUPaths filter sections              
  - Added "Did we miss something? Suggest a new filter" link at bottom of filters tab (opens    
  feedback modal)                                                                               
                                                                                                
  Scheduler Generator (calendar)                                                             
  - Fixed 8px right padding on calendar grid lines                                              
  - Fixed course info popup positioning for async courses (opens below with left-aligned edges) 
  - Fixed popup glitch when clicking between courses or re-clicking the same course (close      
  timeout race condition)                                                                       
                                                                                                
  Feedback Modal                                                                                
  - Made feedback modal controllable via custom open-feedback event so it can be triggered from 
  other components                                                                              
                                                                                                
  Dashboard (Plan Cards)                                                                        
  - Edit Plan & Delete buttons: grey background (bg-neu25), grey border, pointer cursor         
  - Applied Filter tags: white background with grey border, fully rounded, 12px horizontal      
  padding                                                                                       
  - Included Courses cards: grey background, no border/shadow, 8px wide left color bar          
  - Favorited Schedule cards: grey background, grey border, rounded-xl, clickable with hover 
  effect                                                                                        
  - Course tags on schedule cards: colored border and fill background, no left color bar