### PR TITLE
fix: filter only active trackers when sending notifs

### DIFF
--- a/apps/searchneu/app/api/update/route.ts
+++ b/apps/searchneu/app/api/update/route.ts
@@ -7,8 +7,7 @@ import {
   user as usersT,
   subjectsT,
 } from "@/lib/db";
-import { eq, gt } from "drizzle-orm";
-import { sql } from "drizzle-orm";
+import { sql, and, eq, gt, isNull } from "drizzle-orm";
 import { NextRequest } from "next/server";
 import { updateTerm } from "@sneu/scraper/update";
 import { sendNotifications } from "@/lib/updater/notifs";
@@ -67,7 +66,7 @@ export async function GET(req: NextRequest) {
       .innerJoin(coursesT, eq(coursesT.id, sectionsT.courseId))
       .innerJoin(subjectsT, eq(coursesT.subject, subjectsT.id))
       .innerJoin(usersT, eq(usersT.id, trackersT.userId))
-      .where(eq(termsT.term, term));
+      .where(and(eq(termsT.term, term), isNull(trackersT.deletedAt)));
 
     const seatCrns = newSeats.map((s) => s.courseReferenceNumber);
     const seatNotifs = trackers.filter((t) => seatCrns.includes(t.sectionCrn));


### PR DESCRIPTION
# Pull Request

Add a check to only send notifs to active trackers.

Closes #395 

## Type of Change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a PCP (ie changes in deps, database, infrastructure, or package exports)

## Testing

I didnt

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] I have run a build for the entire monorepo
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commits are atomic and my branch is cleaned (no WIP commits)
