### PR TITLE
fix schdule unfavoriting

### DIFF
--- a/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
+++ b/apps/searchneu/components/scheduler/generator/SchedulerWrapper.tsx
@@ -525,6 +525,13 @@ export function SchedulerWrapper({
         // Unfavorite logic
         const favoritedId = favoritedSchedules.get(key);
         if (favoritedId) {
+          // optimistic update — remove immediately
+          setFavoritedSchedules((prev) => {
+            const next = new Map(prev);
+            next.delete(key);
+            return next;
+          });
+
           fetch(`/api/scheduler/favorited-schedules/${favoritedId}`, {
             method: "DELETE",
           }).catch((error) => {


### PR DESCRIPTION
# Pull Request

Adds optimistic update for unfavoriting schedules. Previously, clicking the star on a favorited schedule would keep it red until the DELETE request completed, while favoriting was instant. Now both directions update the UI immediately and revert if the API call fails.

## Type of Change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a PCP (ie changes in deps, database, infrastructure, or package exports)

## Testing

Please describe how you tested this PR (both manually and with tests) Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [ ] I have made corresponding changes to the documentation
- [ ] I have run a build for the entire monorepo
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] All commits are atomic and my branch is cleaned (no WIP commits)
