### PR TITLE
set concentration as empty string

### DIFF
--- a/apps/searchneu/components/graduate/modal/EditPlanModal.tsx
+++ b/apps/searchneu/components/graduate/modal/EditPlanModal.tsx
@@ -214,7 +214,7 @@ export default function EditPlanModal({
       const validConcentrations = majorData?.concentrations ?? [];
       const finalConcentration = validConcentrations.includes(concentration)
         ? concentration
-        : undefined;
+        : "";
 
       if (isGuest && onGuestSave) {
         const current = JSON.parse(localStorage.getItem("guest-plan") ?? "{}");
@@ -271,9 +271,7 @@ export default function EditPlanModal({
           majors: isNoMajorSelected ? null : majors,
           minors: !minors?.length ? null : minors,
           catalogYear: isNoMajorSelected ? null : catalogYear,
-          concentration: isNoMajorSelected
-            ? null
-            : (finalConcentration ?? null),
+          concentration: isNoMajorSelected ? "" : finalConcentration,
         }),
       });
 


### PR DESCRIPTION
# Pull Request

previously concentration was not being cleared correctly after changing year / major on the edit plan modal


## Type of Change

Please tick the boxes that best match your changes.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a PCP (ie changes in deps, database, infrastructure, or package exports)

## Testing

created a plan with a mjor and a concentration, then switched to a different major with no concentration, plan was able to update correctly. previously it would keep the original concentration if new major didnt have concentration options
<img width="614" height="254" alt="image" src="https://github.com/user-attachments/assets/d9a33eb5-03b1-4827-b1f7-4e9a13b00439" />


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] I have run a build for the entire monorepo
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commits are atomic and my branch is cleaned (no WIP commits)
