### PR TITLE
feat: add turbo setup task to automate dev bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+# but do commit the example templates used by `pnpm setup`
+!.env.example
+!**/.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -45,7 +45,27 @@ TODO
 
 ## quickstart
 
-View the README files in the desired application for quickstart instructions.
+Make sure [Docker](https://www.docker.com/) is installed and running, then:
+
+```sh
+pnpm install   # install dependencies (pnpm is the package manager)
+turbo setup    # creates .env files, starts the database, runs migrations
+turbo dev      # start the dev servers (app on http://localhost:3000)
+```
+
+Apart from `pnpm install`, every workflow runs through turbo. `turbo setup` is
+idempotent — re-run it any time (e.g. after restarting Docker).
+
+Course catalog data is **not** seeded automatically (it requires a live Banner
+scrape). The app runs fine against an empty database; to populate courses:
+
+```sh
+turbo cli -- generate --terms=all        # scrape Banner -> cache
+turbo cli -- tools seed-config --seed     # write static config
+turbo cli -- upload --terms=all           # load into the database
+```
+
+For app-specific details, see the README in each application under `apps/`.
 
 ## BEATS
 

--- a/apps/cli/.env.example
+++ b/apps/cli/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to `.env` and adjust as needed.
+# `pnpm setup` does this for you automatically if `.env` is missing.
+
+# Direct TCP connection to local Postgres (started by `docker compose`).
+# The CLI and drizzle-kit migrations use the node-postgres driver and connect
+# straight to port 5432, bypassing the Neon proxy that the web app uses.
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/main

--- a/apps/searchneu/.env.example
+++ b/apps/searchneu/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to `.env` (or `.env.local`) and adjust as needed.
+# `pnpm setup` does this for you automatically if `.env` is missing.
+
+# Local Postgres, accessed through the Neon HTTP proxy that `docker compose`
+# starts on port 4444. The app uses the Neon serverless driver, so it must talk
+# to the proxy host (db.localtest.me resolves to 127.0.0.1) rather than 5432.
+DATABASE_URL=postgres://postgres:postgres@db.localtest.me:4444/main
+
+# --- Auth (optional for local dev) ---
+# Leave the Google credentials blank to develop without OAuth login.
+BETTER_AUTH_URL=http://localhost:3000
+BETTER_AUTH_SECRET=dev-secret-change-me
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# --- Twilio (optional; only needed for SMS section trackers) ---
+TWILIO_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_VERIFY_SID=
+TWILIO_PHONE_NUMBER=

--- a/apps/searchneu/.gitignore
+++ b/apps/searchneu/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sneu",
   "private": true,
   "scripts": {
+    "setup": "node scripts/setup.mjs",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
@@ -11,7 +12,7 @@
     "db:migrate": "turbo run db:migrate --filter=@sneu/db",
     "db:push": "turbo run db:push --filter=@sneu/db",
     "db:studio": "turbo run db:studio --filter=@sneu/db",
-    "cli": "turbo run cli --filter=@sneu/scraper-cli"
+    "cli": "turbo run cli --filter=@sneu/cli"
   },
   "devDependencies": {
     "prettier": "^3.8.3",

--- a/scripts/setup.mjs
+++ b/scripts/setup.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * One-shot, idempotent dev bootstrap.
+ *
+ * Codifies the known-good startup sequence so a fresh clone is ready to run
+ * with a single command. Every step is safe to re-run:
+ *   - .env files are only created when missing (never overwritten)
+ *   - `docker compose --wait` no-ops when containers are already healthy
+ *   - drizzle-kit skips migrations that have already been applied
+ *
+ * Usage: `pnpm setup`
+ *
+ * Catalog/course data is intentionally NOT seeded here (it requires a live
+ * Banner scrape). The script prints the opt-in command at the end.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, copyFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Direct TCP URL used by drizzle-kit migrations (bypasses the Neon proxy).
+const MIGRATION_DATABASE_URL =
+  "postgres://postgres:postgres@localhost:5432/main";
+
+const c = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+};
+
+let step = 0;
+const log = {
+  step: (msg) => console.log(`\n${c.cyan}${c.bold}[${++step}] ${msg}${c.reset}`),
+  info: (msg) => console.log(`    ${c.dim}${msg}${c.reset}`),
+  ok: (msg) => console.log(`    ${c.green}✓ ${msg}${c.reset}`),
+  warn: (msg) => console.log(`    ${c.yellow}! ${msg}${c.reset}`),
+};
+
+/** Run a command, inheriting stdio. Exits the process on failure. */
+function run(cmd, args, { env, label } = {}) {
+  log.info(`$ ${cmd} ${args.join(" ")}`);
+  const result = spawnSync(cmd, args, {
+    cwd: root,
+    stdio: "inherit",
+    env: { ...process.env, ...env },
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) {
+    console.error(
+      `\n${c.red}${c.bold}✗ ${label ?? cmd} failed${c.reset} ${c.dim}(exit ${
+        result.status ?? "unknown"
+      })${c.reset}`,
+    );
+    process.exit(result.status ?? 1);
+  }
+}
+
+/** True if a command exists and returns exit code 0. */
+function check(cmd, args) {
+  const result = spawnSync(cmd, args, {
+    stdio: "ignore",
+    shell: process.platform === "win32",
+  });
+  return result.status === 0;
+}
+
+function ensureEnvFile(relDir) {
+  const dir = path.join(root, relDir);
+  const example = path.join(dir, ".env.example");
+  const target = path.join(dir, ".env");
+  if (!existsSync(example)) {
+    log.warn(`${relDir}/.env.example not found, skipping`);
+    return;
+  }
+  if (existsSync(target)) {
+    log.ok(`${relDir}/.env already exists`);
+    return;
+  }
+  copyFileSync(example, target);
+  log.ok(`created ${relDir}/.env from .env.example`);
+}
+
+console.log(`${c.bold}sneu dev environment setup${c.reset}`);
+
+// 1. Docker must be running before anything else.
+log.step("Checking Docker");
+if (!check("docker", ["info"])) {
+  console.error(
+    `\n${c.red}${c.bold}✗ Docker doesn't appear to be running.${c.reset}\n` +
+      `    Start Docker Desktop (or your daemon) and re-run ${c.bold}pnpm setup${c.reset}.`,
+  );
+  process.exit(1);
+}
+log.ok("Docker is running");
+
+// 2. Create local env files from the committed templates.
+log.step("Setting up environment files");
+ensureEnvFile("apps/searchneu");
+ensureEnvFile("apps/cli");
+
+// 3. Start Postgres + the Neon proxy and wait for the healthcheck to pass.
+log.step("Starting database containers");
+run("docker", ["compose", "up", "-d", "--wait"], { label: "docker compose" });
+log.ok("Postgres + Neon proxy are healthy");
+
+// 4. Build the workspace packages the app/migrations import from dist/.
+log.step("Building workspace packages");
+run(
+  "pnpm",
+  ["--filter", "@sneu/db", "--filter", "@sneu/scraper", "build"],
+  { label: "pnpm build" },
+);
+log.ok("@sneu/db and @sneu/scraper built");
+
+// 5. Apply database migrations (idempotent — drizzle skips applied ones).
+//    Call the @sneu/db package script directly (drizzle-kit) rather than the
+//    root `db:migrate`, which would invoke turbo recursively inside this task.
+log.step("Running database migrations");
+run("pnpm", ["--filter", "@sneu/db", "db:migrate"], {
+  env: { DATABASE_URL: MIGRATION_DATABASE_URL },
+  label: "db:migrate",
+});
+log.ok("Migrations applied");
+
+// Done.
+console.log(`\n${c.green}${c.bold}✓ Setup complete.${c.reset}\n`);
+console.log(`${c.bold}Start the dev servers:${c.reset}`);
+console.log(`  ${c.cyan}turbo dev${c.reset}`);
+console.log(`\n${c.bold}Optional — load course catalog data${c.reset} ${c.dim}(requires a live Banner scrape):${c.reset}`);
+console.log(`  ${c.cyan}turbo cli -- generate --terms=all${c.reset}`);
+console.log(`  ${c.cyan}turbo cli -- tools seed-config --seed${c.reset}`);
+console.log(`  ${c.cyan}turbo cli -- upload --terms=all${c.reset}`);
+console.log("");

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,10 @@
   "$schema": "https://v2-8-0.turborepo.dev/schema.json",
   "ui": "tui",
   "tasks": {
+    "//#setup": {
+      "cache": false,
+      "passThroughEnv": ["DOCKER_*", "COMPOSE_*"]
+    },
     "build": {
       "env": [
         "NODE_ENV",


### PR DESCRIPTION
Replace the manual multi-step startup (docker compose up, db:migrate, catalog upload, dev) with a single idempotent `turbo setup` task that:

- verifies Docker is running
- creates .env files from committed templates if missing
- starts Postgres + Neon proxy and waits for the healthcheck
- builds @sneu/db and @sneu/scraper
- runs database migrations

Catalog seeding stays opt-in (it requires a live Banner scrape) and the script prints the commands. Also commit .env.example templates, un-ignore them, and fix the broken root `cli` filter (@sneu/scraper-cli -> @sneu/cli).

# Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation, context, or
screenshots for frontend changes.

Closes #396 
PCP 

## Type of Change

Please tick the boxes that best match your changes.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] This change requires a PCP (ie changes in deps, database, infrastructure, or package exports)

## Testing


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have made corresponding changes to the documentation
- [x] I have run a build for the entire monorepo
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] All commits are atomic and my branch is cleaned (no WIP commits)
