### PR TITLE
fix(graduate): use null instead of -1 sentinel for catalog year

### DIFF
--- a/apps/searchneu/components/graduate/modal/EditPlanModal.tsx
+++ b/apps/searchneu/components/graduate/modal/EditPlanModal.tsx
@@ -78,7 +78,9 @@ export default function EditPlanModal({
   const [isNoMajorSelected, setIsNoMajorSelected] = useState(
     !plan.majors?.length,
   );
-  const [catalogYear, setCatalogYear] = useState(plan.catalogYear ?? -1);
+  const [catalogYear, setCatalogYear] = useState<number | null>(
+    plan.catalogYear ?? null,
+  );
   const [majors, setMajors] = useState<string[]>(
     plan.majors?.map((m) => m.name) ?? [],
   );
@@ -120,7 +122,7 @@ export default function EditPlanModal({
     if (open) {
       // eslint-disable-next-line
       setMessage(plan.name);
-      setCatalogYear(plan.catalogYear ?? -1);
+      setCatalogYear(plan.catalogYear ?? null);
       setMajors(plan.majors?.map((m) => m.name) ?? []);
       setMinors(plan.minors?.map((m) => m.name) ?? []);
       setConcentration(plan.concentration ?? "");
@@ -188,7 +190,7 @@ export default function EditPlanModal({
   function handleClose() {
     // reset to plan values on cancel
     setMessage(plan.name);
-    setCatalogYear(plan.catalogYear ?? -1);
+    setCatalogYear(plan.catalogYear ?? null);
     setMajors(plan.majors?.map((m) => m.name) ?? []);
     setMinors(plan.minors?.map((m) => m.name) ?? []);
     setConcentration(plan.concentration ?? "");
@@ -202,11 +204,11 @@ export default function EditPlanModal({
     setMinors([]);
     setConcentration("");
     // also clear catalog year — no major means none of these fields are meaningful
-    setCatalogYear(-1);
+    setCatalogYear(null);
   }
 
-  function handleCatalogYearChange(v: string) {
-    setCatalogYear(Number(v));
+  function handleCatalogYearChange(v: string | null) {
+    setCatalogYear(v === null ? null : Number(v));
     // cascade: different year = different requirements, wipe dependent fields
     setMajors([]);
     setMinors([]);
@@ -218,7 +220,9 @@ export default function EditPlanModal({
     setIsSubmitting(true);
     try {
       const majorData =
-        supportedMajorsData?.supportedMajors[catalogYear]?.[majors[0]];
+        catalogYear === null
+          ? undefined
+          : supportedMajorsData?.supportedMajors[catalogYear]?.[majors[0]];
       const validConcentrations = majorData?.concentrations ?? [];
       const finalConcentration = validConcentrations.includes(concentration)
         ? concentration
@@ -231,7 +235,9 @@ export default function EditPlanModal({
           name: message || plan.name,
           majors: isNoMajorSelected ? undefined : majors,
           minors: !minors?.length ? undefined : minors,
-          catalogYear: isNoMajorSelected ? undefined : catalogYear,
+          catalogYear: isNoMajorSelected
+            ? undefined
+            : (catalogYear ?? undefined),
           concentration: isNoMajorSelected
             ? undefined
             : (finalConcentration ?? undefined),
@@ -340,8 +346,8 @@ export default function EditPlanModal({
               CATALOG YEAR
             </Label>
             <Select
-              value={catalogYear === -1 ? "" : catalogYear.toString()}
-              onValueChange={(v) => handleCatalogYearChange(v ?? "")}
+              value={catalogYear === null ? null : String(catalogYear)}
+              onValueChange={(v: string | null) => handleCatalogYearChange(v)}
             >
               <SelectTrigger
                 className="border-neu3 w-full rounded-4xl border bg-transparent"
@@ -378,13 +384,13 @@ export default function EditPlanModal({
                   setMajors(newMajors);
                   setConcentration(""); // changing major clears concentration
                 }}
-                disabled={catalogYear === -1}
+                disabled={catalogYear === null}
               >
                 <ComboboxChips
                   ref={majorsAnchorRef}
                   className={cn(
                     "border-neu3 w-full rounded-4xl bg-transparent",
-                    catalogYear === -1 &&
+                    catalogYear === null &&
                       "bg-neu3 cursor-not-allowed opacity-50",
                   )}
                 >
@@ -507,13 +513,13 @@ export default function EditPlanModal({
                 multiple
                 value={minors}
                 onValueChange={setMinors}
-                disabled={catalogYear === -1}
+                disabled={catalogYear === null}
               >
                 <ComboboxChips
                   ref={minorsAnchorRef}
                   className={cn(
                     "border-neu3 w-full rounded-4xl bg-transparent",
-                    catalogYear === -1 &&
+                    catalogYear === null &&
                       "bg-neu3 cursor-not-allowed opacity-50",
                   )}
                 >
@@ -560,7 +566,7 @@ export default function EditPlanModal({
                 disabled={
                   isSubmitting ||
                   (!isNoMajorSelected && majors.length === 0) ||
-                  (!isNoMajorSelected && catalogYear <= 0) ||
+                  (!isNoMajorSelected && catalogYear === null) ||
                   (!isNoMajorSelected &&
                     concentration_options.length > 0 &&
                     concentration.length === 0)

--- a/apps/searchneu/components/graduate/modal/NewPlanModal.tsx
+++ b/apps/searchneu/components/graduate/modal/NewPlanModal.tsx
@@ -76,7 +76,7 @@ export default function NewPlanModal({
   const [message, setMessage] = useState("");
   const [isNoMajorSelected, setIsNoMajorSelected] = useState(false);
   const [isNoMinorSelected, setIsNoMinorSelected] = useState(false);
-  const [catalogYear, setCatalogYear] = useState(-1);
+  const [catalogYear, setCatalogYear] = useState<number | null>(null);
   //const { data: session } = authClient.useSession();
 
   //majors
@@ -157,7 +157,7 @@ export default function NewPlanModal({
     setMessage("");
     setIsNoMajorSelected(false);
     setIsNoMinorSelected(false);
-    setCatalogYear(-1);
+    setCatalogYear(null);
     setMajors([]);
     setMinors([]);
     setConcentration("");
@@ -306,7 +306,7 @@ export default function NewPlanModal({
         schedule: schedule,
         majors: isNoMajorSelected ? undefined : majors,
         minors: isNoMinorSelected || !minors?.length ? undefined : minors,
-        catalogYear: isNoMajorSelected ? undefined : catalogYear,
+        catalogYear: isNoMajorSelected ? undefined : (catalogYear ?? undefined),
         concentration: isNoMajorSelected
           ? undefined
           : concentration || undefined,
@@ -421,8 +421,10 @@ export default function NewPlanModal({
                     CATALOG YEAR
                   </Label>
                   <Select
-                    value={catalogYear.toString()}
-                    onValueChange={(newYear) => setCatalogYear(Number(newYear))}
+                    value={catalogYear === null ? null : String(catalogYear)}
+                    onValueChange={(newYear: string | null) =>
+                      setCatalogYear(newYear === null ? null : Number(newYear))
+                    }
                   >
                     <SelectTrigger
                       className="border-neu3 w-full rounded-4xl border bg-transparent"
@@ -457,13 +459,13 @@ export default function NewPlanModal({
                     multiple
                     value={majors}
                     onValueChange={setMajors}
-                    disabled={catalogYear == -1}
+                    disabled={catalogYear === null}
                   >
                     <ComboboxChips
                       ref={majorsAnchorRef}
                       className={cn(
                         "border-neu3 w-full rounded-4xl bg-transparent",
-                        catalogYear == -1 &&
+                        catalogYear === null &&
                           "bg-neu3 cursor-not-allowed opacity-50",
                       )}
                     >
@@ -584,13 +586,13 @@ export default function NewPlanModal({
                     multiple
                     value={minors}
                     onValueChange={setMinors}
-                    disabled={catalogYear == -1}
+                    disabled={catalogYear === null}
                   >
                     <ComboboxChips
                       ref={minorsAnchorRef}
                       className={cn(
                         "border-neu3 w-full rounded-4xl bg-transparent",
-                        catalogYear == -1 &&
+                        catalogYear === null &&
                           "bg-neu3 cursor-not-allowed opacity-50",
                       )}
                     >
@@ -713,7 +715,7 @@ export default function NewPlanModal({
                     disabled={
                       isSubmitting ||
                       (!isNoMajorSelected && majors.length == 0) ||
-                      catalogYear <= 2000 ||
+                      catalogYear === null ||
                       (concentrationOptions.length > 0 &&
                         concentration.length == 0) ||
                       (useRecommendedTemplate &&

--- a/apps/searchneu/lib/graduate/useGraduateApi.ts
+++ b/apps/searchneu/lib/graduate/useGraduateApi.ts
@@ -57,7 +57,10 @@ export function useSupportedMinors() {
   return { data, error };
 }
 
-export function useHasTemplate(majorNames: string[], catalogYear: number) {
+export function useHasTemplate(
+  majorNames: string[],
+  catalogYear: number | null,
+) {
   const [hasTemplate, setHasTemplate] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 


### PR DESCRIPTION
The catalog year dropdown never showed its placeholder. `NewPlanModal` displayed a literal `-1`; `EditPlanModal` showed a blank trigger.

Both modals used `-1` as a "nothing selected" sentinel and passed it into Base UI's `Select`. Base UI's `hasSelectedValue` selector only returns false when the value is `== null`, so `"-1"` and `""` both counted as real selections: the placeholder was suppressed and `data-placeholder:text-neu7` on the trigger never applied.

Replaces the sentinel with `number | null` in both modals.

## Changes

- `catalogYear` is now `number | null` in `NewPlanModal` and `EditPlanModal`
- Updated the disabled/styling guards, and the submit guards that leaned on the sentinel's numeric value (`catalogYear <= 2000` and `catalogYear <= 0`)
- `onValueChange` handlers take `string | null` instead of coercing `null` into `""` / `0`
- Create payload uses `?? undefined` (`CreateAuditPlanDto.catalogYear` is optional-`number`); the PATCH body still sends `null`, which `UpdateAuditPlanDto` already accepts as `.nullable().optional()`
- `useHasTemplate` widened to `number | null`; its existing falsy guard already handled it
- Guarded a `supportedMajors[catalogYear]` record lookup in `handleEditPlan` that would not have compiled once the type widened

## Testing

- `tsc --noEmit` clean
- ESLint matches baseline (2 pre-existing unused-disable warnings in `NewPlanModal`, in effects untouched here)
- Prettier clean
- Verified in the new-plan and edit-plan flows against a locally populated catalog

## Note for reviewers

You need `catalog_majors` / `catalog_minors` populated to exercise this — an empty table makes the dropdown look broken regardless of this change. See `apps/cli/POPULATE_CATALOG.md`.